### PR TITLE
make PR to our homebrew tap

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -210,3 +210,31 @@ jobs:
         with:
           path: releases
           destination: dl.kittycad.io
+      - uses: actions/checkout@v3
+        with:
+          repository: 'kittycad/homebrew-kittycad'
+          path: 'homebrew-kittycad'
+          token: ${{secrets.GLOBAL_PAT}}
+      - name: 'replacing Formula/kittycad.rb with ./hombrew/kittycad.rb'
+        shell: bash
+        run: |
+          cp ./homebrew/kittycad.rb homebrew-kittycad/Formula/kittycad.rb
+      - name: commit the changes in the repo
+        shell: bash
+        run: |
+          cd homebrew-kittycad
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git commit -am "YOYO BREW FORMULAR! 🍻" || exit 0
+          git fetch origin
+          git rebase origin/main || exit 0
+          export NEW_BRANCH="update-tap-formula"
+          git checkout -b "$NEW_BRANCH"
+          git push -f origin "$NEW_BRANCH"
+          gh pr create --title "Update tap formula" \
+              --body "Updating the formular for our homebrew tap" \
+              --head "$NEW_BRANCH" \
+              --base main || true
+        env:
+          GITHUB_TOKEN: ${{secrets.GLOBAL_PAT}}


### PR DESCRIPTION
This should resolve https://github.com/KittyCAD/cli/issues/17 finally.

I had done 99% of the work, but I created the "homebrew tap" repo manually in https://github.com/KittyCAD/homebrew-kittycad, but didn't create the final step of making PR's to that repo from this repo.

Putting you on Review @jessfraz, in part because I wanted to ask you about #193, I had planned on implementing that with this change, however when I went to do it I remembered that workflows can't [depend on each other](https://github.com/orgs/community/discussions/26632) before running (at least not without ugly hacks).

Having them in the same workflow means I can use the `needs` property. Also you mentioned the matrix and it running twice, I don't think it does run twice since it's in a different job?

I get that having the homebrew fail making it look like the rest of the release has failed is not ideal, but at least it should be clear once you click into the action-run
![image](https://user-images.githubusercontent.com/29681384/229439840-e33efa5e-b119-49d7-8c5b-6ee767b84b97.png)
