### PR TITLE
Fix typos in actions

### DIFF
--- a/.github/workflows/cargo-build-stable.yml
+++ b/.github/workflows/cargo-build-stable.yml
@@ -7,7 +7,6 @@ on:
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/cargo-build.yml
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - 'spec.json'
   pull_request:
@@ -16,7 +15,6 @@ on:
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/cargo-build.yml
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - 'spec.json'
 name: cargo build (stable)

--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -7,7 +7,6 @@ on:
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/cargo-clippy.yml
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - 'spec.json'
   pull_request:
@@ -15,8 +14,7 @@ on:
       - '**.rs'
       - Cargo.toml
       - Cargo.lock
-      - .github/workflows/cargo-build.yml
-      - 'rust-toolchain'
+      - .github/workflows/cargo-clippy.yml
       - 'rust-toolchain.toml'
       - 'spec.json'
 name: cargo clippy

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -5,13 +5,11 @@ on:
     paths:
       - '**.rs'
       - 'engine'
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - .github/workflows/cargo-fmt.yml
   pull_request:
     paths:
       - '**.rs'
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - .github/workflows/cargo-fmt.yml
       - 'engine'
@@ -31,10 +29,7 @@ jobs:
         with:
             toolchain: stable
             override: true
-            components: rustfmt, clippy
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.6.2
+            components: rustfmt
 
       - name: Run cargo fmt
         run: |

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -8,7 +8,6 @@ on:
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/cargo-test.yml
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - 'Makefile'
       - 'spec.json'
@@ -18,13 +17,11 @@ on:
       - '**.rs.gen'
       - Cargo.toml
       - Cargo.lock
-      - .github/workflows/cargo-build.yml
-      - 'rust-toolchain'
+      - .github/workflows/cargo-test.yml
       - 'rust-toolchain.toml'
       - 'Makefile'
       - 'spec.json'
   workflow_dispatch:
-    inputs:
 permissions: read-all
 name: cargo test
 jobs:
@@ -38,7 +35,6 @@ jobs:
         with:
             toolchain: stable
             override: true
-            components: rustfmt, clippy
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:

--- a/.github/workflows/make-cross.yml
+++ b/.github/workflows/make-cross.yml
@@ -8,7 +8,6 @@ on:
       - Cargo.lock
       - .github/workflows/make-cross.yml
       - Makefile
-      - 'rust-toolchain'
       - 'rust-toolchain.toml'
       - 'spec.json'
   pull_request:
@@ -16,8 +15,7 @@ on:
       - '**.rs'
       - Cargo.toml
       - Cargo.lock
-      - .github/workflows/cargo-build.yml
-      - 'rust-toolchain'
+      - .github/workflows/make-cross.yml
       - 'rust-toolchain.toml'
       - 'spec.json'
 name: make cross
@@ -35,7 +33,6 @@ jobs:
         with:
             toolchain: stable
             override: true
-            components: rustfmt, clippy
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Install deps
         shell: bash


### PR DESCRIPTION
Also stop watching rust-toolchain because it's been replaced with rust-toolchain.toml and we don't have the old file anymore.