### PR TITLE
Name the bins in homebrew tarfile 'zoo' not 'kittycad'

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -190,7 +190,7 @@ jobs:
             homebrew_name="${homebrew_names[$i]}"
 
             mkdir "./homebrew/$homebrew_name"
-            curl -L "https://dl.zoo.dev/releases/cli/$version/kittycad-$input_name" -o "./homebrew/$homebrew_name/kittycad"
+            curl -L "https://dl.zoo.dev/releases/cli/$version/kittycad-$input_name" -o "./homebrew/$homebrew_name/zoo"
 
             sha256=$(sha256sum "./homebrew/$homebrew_name/kittycad")
             hash=$(printf '%s\n' "$sha256" | cut -d' ' -f1)


### PR DESCRIPTION
I think this will fix https://github.com/KittyCAD/cli/issues/543

Basically the current `brew install kittycad` will download a tarfile that looks like

```
Downloads/kittycad-cli
├── aarch64_darwin
│   └── kittycad
├── aarch64_linux
│   └── kittycad
├── x86_64_darwin
│   └── kittycad
└── x86_64_linux
    └── kittycad
```

then fail because aarch64_darwin (or whatever architecture you're on) doesn't have a file called 'zoo'.

From reading the `make release` I think I've found how those bins get that name:

1. Download each release artifact from GitHub
2. Save them as a file called "kittycad"
3. Tar them all together

So changing step (2) to name them "zoo" should fix.