### PR TITLE
Remove atty crate and dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,12 +65,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi-colors-macro"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c2afa84a2916e88ff06df6fd84e7c89e374a726e392f72dc5e32d6db3c3cf6"
-
-[[package]]
 name = "ansi-str"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,15 +1516,6 @@ name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -3768,58 +3753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal-emoji"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8143568e8d5270b3b8f573ab8bb11a556a5c9e4becdc12241a7eef4c54a55170"
-dependencies = [
- "terminal-supports-emoji",
-]
-
-[[package]]
-name = "terminal-log-symbols"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7569386670bad024a2729d194542c42500615fca75f1139c99b697704f7e46f"
-dependencies = [
- "ansi-colors-macro",
- "terminal-emoji",
-]
-
-[[package]]
-name = "terminal-spinner-data"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aadcf9cbc909865c51ff9ced167a1065201b9b35d7254d530c9520b687ef3f4"
-dependencies = [
- "anyhow",
- "heck 0.3.3",
- "quote",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "terminal-spinners"
-version = "0.3.3"
-source = "git+https://github.com/adamchalmers/terminal-spinners-rs#fa6614d2378ad0d3eaab99122bdcddf24cecf782"
-dependencies = [
- "crossterm",
- "terminal-log-symbols",
- "terminal-spinner-data",
-]
-
-[[package]]
-name = "terminal-supports-emoji"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8873a7a1f2d286cfedc10663a722309b1c74092852cf149aee738cbe901c6eb"
-dependencies = [
- "atty",
- "lazy_static",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4979,7 +4912,6 @@ dependencies = [
  "tabwriter",
  "tempfile",
  "termbg",
- "terminal-spinners",
  "terminal_size",
  "test-context",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,17 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,15 +1520,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -1744,7 +1724,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1770,7 +1750,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
@@ -2166,7 +2146,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4866,7 +4846,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "async-trait",
- "atty",
  "base64 0.22.1",
  "built",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ slog-term = "2"
 tabled = { version = "0.15.0", features = ["ansi"] }
 tabwriter = "1.4.0"
 termbg = "0.5.0"
-terminal-spinners = { git = "https://github.com/adamchalmers/terminal-spinners-rs" }
 terminal_size = "0.3.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 ansi_term = "0.12.1"
 anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.80"
-atty = "0.2.14"
 base64 = "0.22.1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 clap = { version = "4.5.4", features = ["cargo", "derive", "env", "unicode", "help", "wrap_help"] }

--- a/src/iostreams.rs
+++ b/src/iostreams.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::{collections::HashMap, env, process::Command};
 
 use anyhow::{anyhow, Result};
@@ -115,7 +116,7 @@ impl IoStreams {
             return self.stdin_is_tty;
         }
 
-        atty::is(atty::Stream::Stdin)
+        std::io::stdin().is_terminal()
     }
 
     pub fn set_stdout_tty(&mut self, is_tty: bool) {
@@ -128,7 +129,7 @@ impl IoStreams {
             return self.stdout_is_tty;
         }
 
-        atty::is(atty::Stream::Stdout)
+        std::io::stdout().is_terminal()
     }
 
     pub fn set_stderr_tty(&mut self, is_tty: bool) {
@@ -142,7 +143,7 @@ impl IoStreams {
             return self.stderr_is_tty;
         }
 
-        atty::is(atty::Stream::Stderr)
+        std::io::stderr().is_terminal()
     }
 
     #[allow(dead_code)]
@@ -329,8 +330,8 @@ impl IoStreams {
     }
 
     pub fn system() -> Self {
-        let stdout_is_tty = atty::is(atty::Stream::Stdout);
-        let stderr_is_tty = atty::is(atty::Stream::Stderr);
+        let stdout_is_tty = std::io::stdout().is_terminal();
+        let stderr_is_tty = std::io::stderr().is_terminal();
 
         #[cfg(windows)]
         let mut assume_true_color = false;
@@ -364,7 +365,7 @@ impl IoStreams {
             progress_indicator_enabled: false,
 
             stdin_tty_override: false,
-            stdin_is_tty: atty::is(atty::Stream::Stdin),
+            stdin_is_tty: std::io::stdin().is_terminal(),
             stdout_tty_override: false,
             stdout_is_tty,
             stderr_tty_override: false,

--- a/src/iostreams.rs
+++ b/src/iostreams.rs
@@ -221,25 +221,6 @@ impl IoStreams {
     }
 
     #[allow(dead_code)]
-    /// This returns a handle to a spinner. To stop the spinner, call `.stop()` on it.
-    pub fn start_process_indicator(&mut self) -> Option<terminal_spinners::SpinnerHandle> {
-        self.start_process_indicator_with_label("")
-    }
-
-    /// This returns a handle to a spinner. To stop the spinner, call `.stop()` on it.
-    pub fn start_process_indicator_with_label(&mut self, label: &str) -> Option<terminal_spinners::SpinnerHandle> {
-        if !self.progress_indicator_enabled {
-            return None;
-        }
-
-        let pi = terminal_spinners::SpinnerBuilder::new()
-            .spinner(&terminal_spinners::DOTS)
-            .text(label.to_string());
-
-        Some(pi.start())
-    }
-
-    #[allow(dead_code)]
     pub fn terminal_width(&self) -> i32 {
         if self.terminal_width_override > 0 {
             return self.terminal_width_override;

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
-use std::{fs, io::Write};
+use std::{fs, io::IsTerminal, io::Write};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -69,7 +69,7 @@ fn should_check_for_update() -> bool {
         return false;
     }
 
-    !is_ci() && atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr)
+    !is_ci() && std::io::stdout().is_terminal() && std::io::stderr().is_terminal()
 }
 
 /// If we are running in a CI environment.


### PR DESCRIPTION
* We don't show terminal spinners anymore, so let's remove them and their dependencies.
    * If we want to add them back in at some point, we should use lib.rs/spinoff instead as it's still maintained and doesn't use old vulnerable deps.
* Atty is unmaintained and has a RUSTSEC about it. We should use std::io::IsTerminal instead.