### PR TITLE
Replace ansi_term, update openapiv3, openapitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "openapitor"
 version = "0.0.9"
-source = "git+https://github.com/KittyCAD/kittycad.rs?branch=main#be590ea77ee3d82b76097fa11d945418fe5a13fd"
+source = "git+https://github.com/KittyCAD/kittycad.rs?branch=main#9e24947a7248bab8797be6428000976a68658b6f"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "openapiv3"
-version = "1.0.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e56d5c441965b6425165b7e3223cc933ca469834f4a8b4786817a1f9dc4f13"
+checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
 dependencies = [
  "indexmap 2.2.2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,15 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ansitok"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2099,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4843,7 +4843,6 @@ dependencies = [
 name = "zoo"
 version = "0.2.50"
 dependencies = [
- "ansi_term",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -4866,6 +4865,7 @@ dependencies = [
  "kcl-lib",
  "kittycad",
  "log",
+ "nu-ansi-term",
  "num-traits",
  "oauth2",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ansi_term = "0.12.1"
 anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.80"
 base64 = "0.22.1"
@@ -27,6 +26,7 @@ kcl-lib = "0.1.57"
 #kcl-lib = {git = "https://github.com/kittycad/modeling-app", branch = "main"}
 kittycad = { version = "0.3.3", features = ["clap", "tabled", "requests", "retry"] }
 log = "0.4.21"
+nu-ansi-term = "0.50.0"
 num-traits = "0.2.19"
 oauth2 = "4.4.2"
 open = "5.1.3"

--- a/cli-macro-impl/Cargo.toml
+++ b/cli-macro-impl/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 anyhow = "1"
 Inflector = "^0.11.4"
 openapitor = { git = "https://github.com/KittyCAD/kittycad.rs", branch = "main" }
-openapiv3 = "1"
+openapiv3 = "2"
 proc-macro2 = "1"
 quote = "1"
 regex = "1.10"

--- a/cli-macro-impl/src/lib.rs
+++ b/cli-macro-impl/src/lib.rs
@@ -889,7 +889,7 @@ impl Operation {
                 writeln!(
                     ctx.io.out,
                     "{} Edited {}",
-                    cs.success_icon_with_color(ansi_term::Color::Red),
+                    cs.success_icon_with_color(nu_ansi_term::Color::Red),
                     #singular_tag_str,
                 )?;
         };
@@ -1155,7 +1155,7 @@ impl Operation {
                     writeln!(
                         ctx.io.out,
                         "{} Deleted {} {} from {}",
-                        cs.success_icon_with_color(ansi_term::Color::Red),
+                        cs.success_icon_with_color(nu_ansi_term::Color::Red),
                         #singular_tag_str,
                         self.#singular_tag_lc,
                         full_name
@@ -1167,7 +1167,7 @@ impl Operation {
                     writeln!(
                         ctx.io.out,
                         "{} Deleted {} {}",
-                        cs.success_icon_with_color(ansi_term::Color::Red),
+                        cs.success_icon_with_color(nu_ansi_term::Color::Red),
                         #singular_tag_str,
                         full_name
                     )?;
@@ -1178,7 +1178,7 @@ impl Operation {
                 writeln!(
                     ctx.io.out,
                     "{} Deleted {} {}",
-                    cs.success_icon_with_color(ansi_term::Color::Red),
+                    cs.success_icon_with_color(nu_ansi_term::Color::Red),
                     #singular_tag_str,
                     self.#singular_tag_lc
                 )?;

--- a/cli-macro-impl/tests/gen/users.rs.gen
+++ b/cli-macro-impl/tests/gen/users.rs.gen
@@ -94,7 +94,7 @@ impl crate::cmd::Command for CmdUserEdit {
         writeln!(
             ctx.io.out,
             "{} Edited {}",
-            cs.success_icon_with_color(ansi_term::Color::Red),
+            cs.success_icon_with_color(nu_ansi_term::Color::Red),
             "user",
         )?;
         Ok(())
@@ -144,7 +144,7 @@ impl crate::cmd::Command for CmdUserDelete {
         writeln!(
             ctx.io.out,
             "{} Deleted {} {}",
-            cs.success_icon_with_color(ansi_term::Color::Red),
+            cs.success_icon_with_color(nu_ansi_term::Color::Red),
             "user",
             self.user
         )?;

--- a/src/cmd_alias.rs
+++ b/src/cmd_alias.rs
@@ -57,7 +57,7 @@ impl crate::cmd::Command for CmdAliasDelete {
                 writeln!(
                     ctx.io.out,
                     "{} Deleted alias {}; was {}",
-                    cs.success_icon_with_color(ansi_term::Color::Red),
+                    cs.success_icon_with_color(nu_ansi_term::Color::Red),
                     self.alias,
                     expansion
                 )?;

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -46,7 +46,7 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Style::new().bold().paint(t).to_string()
+        nu_ansi_term::Style::new().bold().paint(t).to_string()
     }
 
     pub fn red(&self, t: &str) -> String {
@@ -54,7 +54,7 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Colour::Red.paint(t).to_string()
+        nu_ansi_term::Color::Red.paint(t).to_string()
     }
 
     pub fn yellow(&self, t: &str) -> String {
@@ -62,7 +62,7 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Colour::Yellow.paint(t).to_string()
+        nu_ansi_term::Color::Yellow.paint(t).to_string()
     }
 
     pub fn green(&self, t: &str) -> String {
@@ -70,7 +70,7 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Colour::Green.paint(t).to_string()
+        nu_ansi_term::Color::Green.paint(t).to_string()
     }
 
     #[allow(dead_code)]
@@ -80,7 +80,7 @@ impl ColorScheme {
         }
 
         if self.is_256_enabled {
-            ansi_term::Colour::Fixed(242).paint(t).to_string()
+            nu_ansi_term::Color::Fixed(242).paint(t).to_string()
         } else {
             t.to_string()
         }
@@ -91,7 +91,7 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Colour::Purple.paint(t).to_string()
+        nu_ansi_term::Color::Purple.paint(t).to_string()
     }
 
     #[allow(dead_code)]
@@ -100,7 +100,7 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Colour::Blue.paint(t).to_string()
+        nu_ansi_term::Color::Blue.paint(t).to_string()
     }
 
     pub fn cyan(&self, t: &str) -> String {
@@ -108,14 +108,14 @@ impl ColorScheme {
             return t.to_string();
         }
 
-        ansi_term::Colour::Cyan.paint(t).to_string()
+        nu_ansi_term::Color::Cyan.paint(t).to_string()
     }
 
     pub fn success_icon(&self) -> String {
         self.green("✔")
     }
 
-    pub fn success_icon_with_color(&self, color: ansi_term::Colour) -> String {
+    pub fn success_icon_with_color(&self, color: nu_ansi_term::Color) -> String {
         if self.enabled {
             return color.paint("✔").to_string();
         }
@@ -133,7 +133,7 @@ impl ColorScheme {
     }
 
     #[allow(dead_code)]
-    pub fn failure_icon_with_color(&self, color: ansi_term::Colour) -> String {
+    pub fn failure_icon_with_color(&self, color: nu_ansi_term::Color) -> String {
         if self.enabled {
             return color.paint("✘").to_string();
         }

--- a/src/iostreams.rs
+++ b/src/iostreams.rs
@@ -341,7 +341,7 @@ impl IoStreams {
             // Note for Windows 10 users: On Windows 10, the application must enable ANSI support
             // first.
             #[cfg(windows)]
-            let enabled = ansi_term::enable_ansi_support();
+            let enabled = nu_ansi_term::enable_ansi_support();
             #[cfg(windows)]
             if enabled.is_ok() {
                 assume_true_color = true;


### PR DESCRIPTION
Update openapiv3 and openapitor.

Also, `ansi_term` is unmaintained. The nushell team, which I trust and highly regard, have their own fork called `nu_ansi_term` which I am switching to.
