### PR TITLE
Fix unused code warnings

### DIFF
--- a/src/cmd_config.rs
+++ b/src/cmd_config.rs
@@ -138,12 +138,12 @@ impl crate::cmd::Command for CmdConfigList {
 
         for option in crate::config::config_options() {
             match ctx.config.get(&host, &option.key) {
-                Ok(value) => writeln!(ctx.io.out, "{}={}", option.key, value)?,
+                Ok(value) => writeln!(ctx.io.out, "{}\n{}={}\n", option.description, option.key, value)?,
                 Err(err) => {
                     if host.is_empty() {
                         // Only bail if the host is empty, since some hosts may not have
                         // all the options.
-                        bail!("{}", err);
+                        bail!("{err}");
                     }
                 }
             }

--- a/src/cmd_config.rs
+++ b/src/cmd_config.rs
@@ -172,7 +172,7 @@ mod test {
             TestItem {
                 name: "list empty".to_string(),
                 cmd: crate::cmd_config::SubCommand::List(crate::cmd_config::CmdConfigList { host: "".to_string() }),
-                want_out: "editor=\nprompt=enabled\npager=\nbrowser=\nformat=table\n".to_string(),
+                want_out: "the text editor program to use for authoring text\neditor=\n\ntoggle interactive prompting in the terminal\nprompt=enabled\n\nthe terminal pager program to send standard output to\npager=\n\nthe web browser to use for opening URLs\nbrowser=\n\nthe formatting style for command output\nformat=table\n\n".to_string(),
                 want_err: "".to_string(),
             },
             TestItem {
@@ -235,7 +235,8 @@ mod test {
             TestItem {
                 name: "list all default".to_string(),
                 cmd: crate::cmd_config::SubCommand::List(crate::cmd_config::CmdConfigList { host: "".to_string() }),
-                want_out: "editor=\nprompt=enabled\npager=\nbrowser=bar\nformat=table\n".to_string(),
+                // want_out: "editor=\nprompt=enabled\npager=\nbrowser=bar\nformat=table\n".to_string(),
+                want_out: "the text editor program to use for authoring text\neditor=\n\ntoggle interactive prompting in the terminal\nprompt=enabled\n\nthe terminal pager program to send standard output to\npager=\n\nthe web browser to use for opening URLs\nbrowser=bar\n\nthe formatting style for command output\nformat=table\n\n".to_string(),
                 want_err: "".to_string(),
             },
         ];

--- a/src/iostreams.rs
+++ b/src/iostreams.rs
@@ -34,8 +34,6 @@ pub struct IoStreams {
     pager_process: Option<std::process::Child>,
 
     never_prompt: bool,
-
-    pub tmp_file_override: Option<std::fs::File>,
 }
 
 impl IoStreams {
@@ -378,7 +376,6 @@ impl IoStreams {
 
             pager_process: None,
             never_prompt: false,
-            tmp_file_override: None,
         };
 
         if stdout_is_tty && stderr_is_tty {


### PR DESCRIPTION
Fixes https://github.com/KittyCAD/cli/issues/686

Here's what running `zoo config list` looks like, before and after this PR.

Before:

```
editor=
prompt=enabled
pager=
browser=
format=table
```

After:

```
the text editor program to use for authoring text
editor=

toggle interactive prompting in the terminal
prompt=enabled

the terminal pager program to send standard output to
pager=

the web browser to use for opening URLs
browser=

the formatting style for command output
format=table
```