### PR TITLE
Fix setting a default host through command line

### DIFF
--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -271,7 +271,7 @@ impl crate::cmd::Command for CmdAuthLogin {
         }
 
         // Set the token in the config file.
-        ctx.config.set(host, "token", &token)?;
+        ctx.config.set(host, "token", Some(&token))?;
 
         let client = ctx.api_client(host)?;
 
@@ -282,7 +282,7 @@ impl crate::cmd::Command for CmdAuthLogin {
         let email = session
             .email
             .ok_or_else(|| anyhow::anyhow!("user does not have an email"))?;
-        ctx.config.set(host, "user", &email)?;
+        ctx.config.set(host, "user", Some(&email))?;
 
         // Save the config.
         ctx.config.write()?;

--- a/src/cmd_config.rs
+++ b/src/cmd_config.rs
@@ -1,3 +1,4 @@
+use crate::config::{ConfigOption, CONFIG_OPTIONS};
 use anyhow::{bail, Result};
 use clap::Parser;
 
@@ -82,28 +83,46 @@ pub struct CmdConfigSet {
 #[async_trait::async_trait(?Send)]
 impl crate::cmd::Command for CmdConfigSet {
     async fn run(&self, ctx: &mut crate::context::Context) -> Result<()> {
-        let cs = ctx.io.color_scheme();
+        let is_host_set = !self.host.is_empty();
 
-        // Validate the key.
-        match crate::config::validate_key(&self.key) {
-            Ok(()) => (),
-            Err(_) => {
-                bail!(
-                    "{} warning: '{}' is not a known configuration key",
-                    cs.warning_icon(),
-                    self.key
-                );
-            }
-        }
+        // All top level options are also valid host options.
+        crate::config::validate_key(&self.key)?;
+        crate::config::validate_value(&self.key, &self.value)?;
 
-        // Validate the value.
-        if let Err(err) = crate::config::validate_value(&self.key, &self.value) {
-            bail!("{}", err);
+        if is_host_set {
+            crate::config::validate_key(&self.key)?;
+            crate::config::validate_value(&self.key, &self.value)?;
         }
 
         // Set the value.
-        if let Err(err) = ctx.config.set(&self.host, &self.key, &self.value) {
+        if let Err(err) = ctx.config.set(&self.host, &self.key, Some(&self.value)) {
             bail!("{}", err);
+        }
+
+        // Unset the option in all other hosts if it's a mutually exclusive option.
+        if is_host_set {
+            for option in CONFIG_OPTIONS {
+                if let &ConfigOption::HostLevel {
+                    key,
+                    mutually_exclusive,
+                    ..
+                } = option
+                {
+                    if key != self.key || !mutually_exclusive {
+                        continue;
+                    }
+
+                    for host in ctx.config.hosts()? {
+                        // Skip the host that was the original value target
+                        if host == self.host {
+                            continue;
+                        }
+                        if let Err(err) = ctx.config.set(&host, &self.key, None) {
+                            bail!("{}", err);
+                        }
+                    }
+                }
+            }
         }
 
         // Write the config file.
@@ -136,14 +155,16 @@ impl crate::cmd::Command for CmdConfigList {
             self.host.to_string()
         };
 
-        for option in crate::config::config_options() {
-            match ctx.config.get(&host, &option.key) {
-                Ok(value) => writeln!(ctx.io.out, "{}\n{}={}\n", option.description, option.key, value)?,
-                Err(err) => {
-                    if host.is_empty() {
-                        // Only bail if the host is empty, since some hosts may not have
-                        // all the options.
-                        bail!("{err}");
+        for option in CONFIG_OPTIONS {
+            if let &ConfigOption::TopLevel { key, description, .. } = option {
+                match ctx.config.get(&host, key) {
+                    Ok(value) => writeln!(ctx.io.out, "{}\n{}={}\n", description, key, value)?,
+                    Err(err) => {
+                        if host.is_empty() {
+                            // Only bail if the host is empty, since some hosts may not have
+                            // all the options.
+                            bail!("{err}");
+                        }
                     }
                 }
             }
@@ -158,6 +179,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use crate::cmd::Command;
+    use crate::config;
+    use crate::config::Config;
 
     pub struct TestItem {
         name: String,
@@ -183,7 +206,7 @@ mod test {
                     host: "".to_string(),
                 }),
                 want_out: "".to_string(),
-                want_err: "warning: 'foo' is not a known configuration key".to_string(),
+                want_err: "invalid key: foo".to_string(),
             },
             TestItem {
                 name: "set a key".to_string(),
@@ -264,10 +287,58 @@ mod test {
                     let stdout = std::fs::read_to_string(stdout_path).unwrap();
                     let stderr = std::fs::read_to_string(stderr_path).unwrap();
                     assert_eq!(stdout, t.want_out, "test {}", t.name);
-                    assert!(err.to_string().contains(&t.want_err), "test {}", t.name);
+                    assert_eq!(&err.to_string(), &t.want_err, "test {}", t.name);
                     assert!(stderr.is_empty(), "test {}", t.name);
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_hosts_default_mutually_exclusive() -> Result<(), anyhow::Error> {
+        let mut config = config::new_blank_config().unwrap();
+        assert!(config.set("example.com", "token", Some("abcdef")).is_ok());
+        assert!(config.set("zoo.computer", "token", Some("ghijkl")).is_ok());
+        assert_eq!(config.hosts()?.len(), 2);
+
+        let mut c = crate::config_from_env::EnvConfig::inherit_env(&mut config);
+
+        let (io, _stdout_path, _stderr_path) = crate::iostreams::IoStreams::test();
+        let mut ctx = crate::context::Context {
+            config: &mut c,
+            io,
+            debug: false,
+        };
+
+        let mut cmd_config = crate::cmd_config::CmdConfig {
+            subcmd: crate::cmd_config::SubCommand::Set(crate::cmd_config::CmdConfigSet {
+                key: "default".to_string(),
+                value: "true".to_string(),
+                host: "example.com".to_string(),
+            }),
+        };
+        cmd_config.run(&mut ctx).await?;
+
+        cmd_config = crate::cmd_config::CmdConfig {
+            subcmd: crate::cmd_config::SubCommand::Set(crate::cmd_config::CmdConfigSet {
+                key: "default".to_string(),
+                value: "true".to_string(),
+                host: "zoo.computer".to_string(),
+            }),
+        };
+        cmd_config.run(&mut ctx).await?;
+
+        let config_text = config.hosts_to_string().unwrap();
+        assert_eq!(
+            config_text,
+            r#"["example.com"]
+token = "abcdef"
+
+["zoo.computer"]
+token = "ghijkl"
+default = true"#
+        );
+
+        Ok(())
     }
 }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -123,6 +123,7 @@ impl ColorScheme {
         "✔".to_string()
     }
 
+    #[allow(dead_code)]
     pub fn warning_icon(&self) -> String {
         self.yellow("!")
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ pub trait Config: Send + Sync {
     /// Returns a value from the configuration by its key, with the source.
     fn get_with_source(&self, hostname: &str, key: &str) -> Result<(String, String)>;
     /// Sets a value in the configuration by its key.
-    fn set(&mut self, hostname: &str, key: &str, value: &str) -> Result<()>;
+    fn set(&mut self, hostname: &str, key: &str, value: Option<&str>) -> Result<()>;
 
     /// Remove a host.
     fn unset_host(&mut self, key: &str) -> Result<()>;
@@ -44,64 +44,79 @@ pub trait Config: Send + Sync {
     fn hosts_to_string(&self) -> Result<String>;
 }
 
-pub struct ConfigOption {
-    pub key: String,
-    pub description: String,
-    pub comment: String,
-    pub default_value: String,
-    pub allowed_values: Vec<String>,
+pub enum ConfigOption<'a> {
+    TopLevel {
+        key: &'a str,
+        description: &'a str,
+        comment: &'a str,
+        default_value: &'a str,
+        allowed_values: &'a [&'a str],
+    },
+    HostLevel {
+        key: &'a str,
+        allowed_values: &'a [&'a str],
+        mutually_exclusive: bool,
+    },
 }
 
-pub fn config_options() -> Vec<ConfigOption> {
-    vec![
-        ConfigOption {
-            key: "editor".to_string(),
-            description: "the text editor program to use for authoring text".to_string(),
-            comment: "What editor zoo should run when creating text, etc. If blank, will refer to environment."
-                .to_string(),
-            default_value: "".to_string(),
-            allowed_values: vec![],
-        },
-        ConfigOption {
-            key: "prompt".to_string(),
-            description: "toggle interactive prompting in the terminal".to_string(),
-            comment: "When to interactively prompt. This is a global config that cannot be overridden by hostname."
-                .to_string(),
-            default_value: "enabled".to_string(),
-            allowed_values: vec!["enabled".to_string(), "disabled".to_string()],
-        },
-        ConfigOption {
-            key: "pager".to_string(),
-            description: "the terminal pager program to send standard output to".to_string(),
-            comment: "A pager program to send command output to, e.g. \"less\". Set the value to \"cat\" to disable the pager.".to_string(),
-            default_value: "".to_string(),
-            allowed_values: vec![],
-        },
-        ConfigOption {
-            key: "browser".to_string(),
-            description: "the web browser to use for opening URLs".to_string(),
-            comment: "What web browser zoo should use when opening URLs. If blank, will refer to environment.".to_string(),
-            default_value: "".to_string(),
-            allowed_values: vec![],
-        },
-        ConfigOption {
-            key: "format".to_string(),
-            description: "the formatting style for command output".to_string(),
-            comment: "What formatting zoo should use when printing text.".to_string(),
-            default_value: crate::types::FormatOutput::default().to_string(),
-            allowed_values: crate::types::FormatOutput::variants(),
-        },
-    ]
-}
+pub static CONFIG_OPTIONS: &[ConfigOption] = &[
+    ConfigOption::TopLevel {
+        key: "editor",
+        description: "the text editor program to use for authoring text",
+        comment: "What editor zoo should run when creating text, etc. If blank, will refer to environment.",
+        default_value: "",
+        allowed_values: &[],
+    },
+    ConfigOption::TopLevel {
+        key: "prompt",
+        description: "toggle interactive prompting in the terminal",
+        comment: "When to interactively prompt. This is a global config that cannot be overridden by hostname.",
+        default_value: "enabled",
+        allowed_values: &["enabled", "disabled"],
+    },
+    ConfigOption::TopLevel {
+        key: "pager",
+        description: "the terminal pager program to send standard output to",
+        comment:
+            "A pager program to send command output to, e.g. \"less\". Set the value to \"cat\" to disable the pager.",
+        default_value: "",
+        allowed_values: &[],
+    },
+    ConfigOption::TopLevel {
+        key: "browser",
+        description: "the web browser to use for opening URLs",
+        comment: "What web browser zoo should use when opening URLs. If blank, will refer to environment.",
+        default_value: "",
+        allowed_values: &[],
+    },
+    ConfigOption::TopLevel {
+        key: "format",
+        description: "the formatting style for command output",
+        comment: "What formatting zoo should use when printing text.",
+        // TODO: Use this code when https://github.com/Peternator7/strum/issues/352
+        // is finally merged.
+        // default_value: crate::types::FormatOutput::default().into(),
+        // This is literally the only place in the entire config that would prevent
+        // me from declaring this whole data static. So I'm placing "table" here
+        // instead.
+        default_value: "table",
+        allowed_values: crate::types::FormatOutput::variants(),
+    },
+    ConfigOption::HostLevel {
+        key: "default",
+        allowed_values: &["true", "false"],
+        mutually_exclusive: true,
+    },
+];
 
-pub fn validate_key(key: &str) -> Result<()> {
-    for config_key in config_options() {
-        if key == config_key.key {
+pub fn validate_key(target_key: &str) -> Result<()> {
+    for &ConfigOption::TopLevel { key, .. } | &ConfigOption::HostLevel { key, .. } in CONFIG_OPTIONS {
+        if target_key == key {
             return Ok(());
         }
     }
 
-    Err(anyhow!("invalid key: {}", key))
+    Err(anyhow!("invalid key: {}", target_key))
 }
 
 #[derive(Error, Debug)]
@@ -110,13 +125,19 @@ pub enum InvalidValueError {
     ValidValues(Vec<String>),
 }
 
-pub fn validate_value(key: &str, value: &str) -> Result<()> {
+pub fn validate_value(target_key: &str, value: &str) -> Result<()> {
     let mut valid_values: Vec<String> = vec![];
 
     // Set the valid values for the key.
-    for config_key in config_options() {
-        if config_key.key == key {
-            valid_values = config_key.allowed_values;
+    for &ConfigOption::TopLevel {
+        key, allowed_values, ..
+    }
+    | &ConfigOption::HostLevel {
+        key, allowed_values, ..
+    } in CONFIG_OPTIONS
+    {
+        if target_key == key {
+            valid_values.extend(allowed_values.iter().map(|&s| s.to_string()));
             break;
         }
     }
@@ -136,7 +157,7 @@ pub fn validate_value(key: &str, value: &str) -> Result<()> {
 
 // new_from_string initializes a Config from a toml string.
 #[cfg(test)]
-fn new_from_string(s: &str) -> Result<impl Config> {
+pub fn new_from_string(s: &str) -> Result<impl Config> {
     let root = s.parse::<toml_edit::DocumentMut>()?;
     Ok(new_config(root))
 }
@@ -151,14 +172,23 @@ pub fn new_config(t: toml_edit::DocumentMut) -> impl Config {
 
 pub fn new_blank_root() -> Result<toml_edit::DocumentMut> {
     let mut s = String::new();
-    for option in config_options() {
-        if !option.comment.is_empty() {
-            writeln!(s, "# {}", option.comment)?;
-            if !option.allowed_values.is_empty() {
-                writeln!(s, "# Supported values: {}", option.allowed_values.join(", "))?;
+    for option in CONFIG_OPTIONS {
+        if let &ConfigOption::TopLevel {
+            comment,
+            key,
+            allowed_values,
+            default_value,
+            ..
+        } = option
+        {
+            if !comment.is_empty() {
+                writeln!(s, "# {}", comment)?;
+                if !allowed_values.is_empty() {
+                    writeln!(s, "# Supported values: {}", allowed_values.join(", "))?;
+                }
             }
+            writeln!(s, "{} = \"{}\"\n", key, default_value)?;
         }
-        writeln!(s, "{} = \"{}\"\n", option.key, option.default_value)?;
     }
 
     Ok(s.parse::<toml_edit::DocumentMut>()?)
@@ -179,11 +209,11 @@ mod test {
     #[test]
     fn test_file_config_set_no_host() {
         let mut c = new_blank_config().unwrap();
-        assert!(c.set("", "editor", "vim").is_ok());
-        assert!(c.set("", "prompt", "disabled").is_ok());
-        assert!(c.set("", "pager", "less").is_ok());
-        assert!(c.set("", "browser", "firefox").is_ok());
-        assert!(c.set("", "format", "table").is_ok());
+        assert!(c.set("", "editor", Some("vim")).is_ok());
+        assert!(c.set("", "prompt", Some("disabled")).is_ok());
+        assert!(c.set("", "pager", Some("less")).is_ok());
+        assert!(c.set("", "browser", Some("firefox")).is_ok());
+        assert!(c.set("", "format", Some("table")).is_ok());
 
         let doc = c.config_to_string().unwrap();
         assert!(doc.contains("editor = \"vim\""));
@@ -196,11 +226,11 @@ mod test {
     #[test]
     fn test_file_config_set_with_host() {
         let mut c = new_blank_config().unwrap();
-        assert!(c.set("example.com", "editor", "vim").is_ok());
-        assert!(c.set("example.com", "prompt", "disabled").is_ok());
-        assert!(c.set("example.com", "pager", "less").is_ok());
-        assert!(c.set("example.com", "browser", "firefox").is_ok());
-        assert!(c.set("zoo.computer", "browser", "chrome").is_ok());
+        assert!(c.set("example.com", "editor", Some("vim")).is_ok());
+        assert!(c.set("example.com", "prompt", Some("disabled")).is_ok());
+        assert!(c.set("example.com", "pager", Some("less")).is_ok());
+        assert!(c.set("example.com", "browser", Some("firefox")).is_ok());
+        assert!(c.set("zoo.computer", "browser", Some("chrome")).is_ok());
 
         let doc = c.hosts_to_string().unwrap();
 
@@ -295,10 +325,10 @@ token = "MY_TOKEN""#,
         // Getting the default host should return an error.
         assert_eq!(c.default_host().is_err(), true);
         if let Err(e) = c.default_host() {
-            assert_eq!(e.to_string(), "No host has been set as default. Try setting a default with `zoo config set -H <host> default true`. Options for hosts are: example.org, thing.com");
+            assert_eq!(e.to_string(), "Multiple hosts in config file but none has been set as a default. Try setting a default with `zoo config set -H <host> default true`. Options for hosts are: example.org, thing.com");
         }
 
-        c.set("example.org", "default", "true").unwrap();
+        c.set("example.org", "default", Some("true")).unwrap();
         assert_eq!(c.default_host().unwrap(), "example.org".to_string());
 
         c.unset_host("thing.com").unwrap();
@@ -321,6 +351,9 @@ default = true"#;
         assert!(result.is_ok());
 
         let result = validate_key("browser");
+        assert!(result.is_ok());
+
+        let result = validate_key("default");
         assert!(result.is_ok());
     }
 

--- a/src/config_alias.rs
+++ b/src/config_alias.rs
@@ -22,7 +22,7 @@ impl AliasConfig<'_> {
     }
 
     pub fn add(&mut self, alias: &str, expansion: &str) -> Result<()> {
-        self.map.set_string_value(alias, expansion)?;
+        self.map.set_string_value(alias, Some(expansion))?;
 
         self.parent.save_aliases(&self.map)?;
 

--- a/src/config_from_env.rs
+++ b/src/config_from_env.rs
@@ -48,7 +48,7 @@ impl crate::config::Config for EnvConfig<'_> {
         self.config.get_with_source(hostname, key)
     }
 
-    fn set(&mut self, hostname: &str, key: &str, value: &str) -> Result<()> {
+    fn set(&mut self, hostname: &str, key: &str, value: Option<&str>) -> Result<()> {
         self.config.set(hostname, key, value)
     }
 

--- a/src/config_from_file.rs
+++ b/src/config_from_file.rs
@@ -129,7 +129,7 @@ impl crate::config::Config for FileConfig {
         Ok((value, hosts_source))
     }
 
-    fn set(&mut self, hostname: &str, key: &str, value: &str) -> Result<()> {
+    fn set(&mut self, hostname: &str, key: &str, value: Option<&str>) -> Result<()> {
         if hostname.is_empty() {
             return self.map.set_string_value(key, value);
         }
@@ -214,7 +214,7 @@ impl crate::config::Config for FileConfig {
         }
 
         Err(anyhow!(
-            "No host has been set as default. Try setting a default with `zoo config set -H <host> default true`. Options for hosts are: {}", hosts.join(", ")
+            "Multiple hosts in config file but none has been set as a default. Try setting a default with `zoo config set -H <host> default true`. Options for hosts are: {}", hosts.join(", ")
         ))
     }
 

--- a/src/config_map.rs
+++ b/src/config_map.rs
@@ -29,14 +29,18 @@ impl ConfigMap {
         }
     }
 
-    pub fn set_string_value(&mut self, key: &str, value: &str) -> Result<()> {
-        if key == "default" && (value == "true" || value == "false") {
-            // Add this as a bool.
-            self.root.insert(key, toml_edit::value(value == "true"));
-            return Ok(());
-        }
+    pub fn set_string_value(&mut self, key: &str, value_: Option<&str>) -> Result<()> {
+        if let Some(value) = value_ {
+            if key == "default" && (value == "true" || value == "false") {
+                // Add this as a bool.
+                self.root.insert(key, toml_edit::value(value == "true"));
+                return Ok(());
+            }
 
-        self.root.insert(key, toml_edit::value(value));
+            self.root.insert(key, toml_edit::value(value));
+        } else {
+            self.root.remove(key);
+        }
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -452,11 +452,11 @@ mod test {
             let mut c = crate::config_from_env::EnvConfig::inherit_env(&mut config);
 
             if !t.pager.is_empty() {
-                c.set("", "pager", &t.pager).unwrap();
+                c.set("", "pager", Some(&t.pager)).unwrap();
             }
 
             if !t.prompt.is_empty() {
-                c.set("", "prompt", &t.prompt).unwrap();
+                c.set("", "prompt", Some(&t.prompt)).unwrap();
             }
 
             if !t.zoo_pager_env.is_empty() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,8 +12,8 @@ pub enum FormatOutput {
 }
 
 impl FormatOutput {
-    pub fn variants() -> Vec<String> {
-        vec!["table".to_string(), "json".to_string(), "yaml".to_string()]
+    pub const fn variants() -> &'static [&'static str] {
+        &["table", "json", "yaml"]
     }
 }
 


### PR DESCRIPTION
When trying to set a default host through the command line, the CLI would report that `default` is an invalid key. This is because it was not part of the set of `ConfigOption`'s. The problem with just adding it to there, which I did at first just to see something working, is that these options are also meant to be top-level options. I had to redesign the program a little bit to understand the notion of host-level options and top-level options that can also be host-level options.

A test is added to ensure that only one host can ever be set as `default`.