### PR TITLE
Print Honeycomb traces for KCL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d995122b9b67e54a97d0fe810a8b41c0ca1d1c6b9f03c0689b7ca2a9c524465"
+checksum = "f51e66895b1c30ac533ccea8b39ba5e5cfe3ef43ac56259bae73918963fae70c"
 dependencies = [
  "anyhow",
  "approx",
@@ -1847,6 +1847,7 @@ dependencies = [
  "futures",
  "git_rev",
  "gltf-json",
+ "http 0.2.12",
  "image 0.25.2",
  "js-sys",
  "kittycad",
@@ -1894,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5e9c51976882cdf6777557fd8c3ee68b00bb53e9307fc1721acb397f2ece9a"
+checksum = "1a9621df809fa105ae28b01586c52ce46561e166702babb50e5bcc5097a8ce62"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ git_rev = "0.1.0"
 heck = "0.5.0"
 http = "0.2.6"
 itertools = "0.12.1"
-kcl-lib = { version = "0.2.6", features = ["disable-println"] }
+kcl-lib = { version = "0.2.7", features = ["disable-println"] }
 kcl-test-server = "0.1.8"
-kittycad = { version = "0.3.14", features = ["clap", "tabled", "requests", "retry"] }
+kittycad = { version = "0.3.16", features = ["clap", "tabled", "requests", "retry"] }
 log = "0.4.22"
 nu-ansi-term = "0.50.1"
 num-traits = "0.2.19"


### PR DESCRIPTION
Add a --show-trace flag for KCL commands, which prints the Honeycomb trace URL for the API requests used to execute the KCL.