### PR TITLE
Bump KCL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ git_rev = "0.1.0"
 heck = "0.5.0"
 http = "1"
 itertools = "0.12.1"
-kcl-lib = { version = "0.2.21", features = ["disable-println"] }
-kcl-test-server = "0.1.13"
+kcl-lib = { version = "0.2.22", features = ["disable-println"] }
+kcl-test-server = "0.1.14"
 kittycad = { version = "0.3.23", features = ["clap", "tabled", "requests", "retry"] }
 kittycad-modeling-cmds = { version = "0.2.69", features = ["websocket", "convert_client_crate", "tabled"] }
 log = "0.4.22"


### PR DESCRIPTION
It was already bumped in Cargo.lock but the Cargo.toml is clearer.