### PR TITLE
feat(copilot): kittycad 0.3.42, markdown reasoning, try to keep up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3094724243b225d7f2d5db1113404853dfe27cc7150dcff7e5bd6395bf216718"
+checksum = "48b1831f8d66ab867f64a4e287ec9740f105d17446ac0a5fe53ec3442383cb43"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ itertools = "0.12.1"
 kcl-derive-docs = { version = "=0.1.95" }
 kcl-lib = { version = "=0.2.95", features = ["disable-println"] }
 kcl-test-server = "=0.1.95"
-kittycad = { version = "0.3.41", features = [
+kittycad = { version = "0.3.42", features = [
   "clap",
   "tabled",
   "requests",
@@ -47,7 +47,10 @@ kittycad-modeling-cmds = { version = "=0.2.133", features = [
   "convert_client_crate",
   "tabled",
 ] }
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+image = { version = "0.25", default-features = false, features = [
+  "png",
+  "jpeg",
+] }
 log = "0.4.27"
 miette = { version = "7.5.0", features = ["fancy"] }
 nu-ansi-term = "0.50.1"
@@ -57,7 +60,9 @@ open = "5.3.2"
 parse-display = "0.10.0"
 pulldown-cmark = "0.9.2"
 pulldown-cmark-to-cmark = "11.0.2"
-ratatui = { version = "0.26", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.26", default-features = false, features = [
+  "crossterm",
+] }
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/src/context.rs
+++ b/src/context.rs
@@ -710,6 +710,9 @@ pub(crate) fn format_reasoning(reason: kittycad::types::ReasoningMessage, use_co
         kittycad::types::ReasoningMessage::Text { content } => {
             vec![format!("{} {}", lbl("reasoning:", Color::Cyan), content.trim())]
         }
+        kittycad::types::ReasoningMessage::Markdown { content } => {
+            vec![format!("{} {}", lbl("reasoning:", Color::Cyan), content.trim())]
+        }
         kittycad::types::ReasoningMessage::KclDocs { content } => {
             vec![format!("{} {}", lbl("kcl docs:", Color::Purple), content.trim())]
         }
@@ -769,6 +772,7 @@ pub(crate) fn reasoning_to_markdown(reason: &kittycad::types::ReasoningMessage) 
 
     match reason {
         kittycad::types::ReasoningMessage::Text { content } => content.trim().to_string(),
+        kittycad::types::ReasoningMessage::Markdown { content } => content.trim().to_string(),
         kittycad::types::ReasoningMessage::KclDocs { content } => {
             format!("**KCL Docs**\n\n{}", content.trim())
         }

--- a/src/ml/copilot/run.rs
+++ b/src/ml/copilot/run.rs
@@ -54,6 +54,7 @@ fn build_user_message(
         current_files: Some(files),
         project_name: project_name.clone(),
         source_ranges: None,
+        forced_tools: Default::default(),
     };
     let len = serde_json::to_string(&msg).map(|s| s.len()).unwrap_or(0);
     (msg, len)

--- a/src/ml/copilot/ui.rs
+++ b/src/ml/copilot/ui.rs
@@ -175,6 +175,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
                 kittycad::types::MlCopilotServerMessage::Delta { delta } => {
                     assistant_buf.push_str(delta);
                 }
+                kittycad::types::MlCopilotServerMessage::ConversationId { .. } => {
+                    // Ignore conversation ID we don't care.
+                }
                 kittycad::types::MlCopilotServerMessage::EndOfStream { .. } => {
                     if !assistant_buf.is_empty() {
                         let rows = render_preserving_newlines(&assistant_buf);


### PR DESCRIPTION
- Handle ReasoningMessage::Markdown in formatting and markdown output
- Adapt to API changes, set forced_tools default, ignore ConversationId