### PR TITLE
fix(docs): normalize generated CLI arg descriptions for MDX builds

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,0 +1,71 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: documentation build
+jobs:
+  documentationbuild:
+    name: generated CLI docs build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CLI
+        uses: actions/checkout@v6
+
+      - name: Install latest rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5.0.4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v5.0.4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v5.0.4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Generate CLI markdown
+        run: make gen-md
+
+      - name: Checkout documentation
+        uses: actions/checkout@v6
+        with:
+          repository: kittycad/documentation
+          path: docs
+          persist-credentials: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install documentation dependencies
+        run: npm ci
+        working-directory: docs
+
+      - name: Replace generated CLI docs
+        run: |
+          rm -rf docs/content/pages/docs/cli/manual/kittycad*.md
+          rm -rf docs/content/pages/docs/cli/manual/zoo*.md
+          mv -f generated_docs/md/zoo*.md docs/content/pages/docs/cli/manual/
+
+      - name: Build documentation
+        run: npm run build
+        working-directory: docs

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -49,15 +49,13 @@ jobs:
           path: docs
           persist-credentials: false
 
-      - name: Install Node.js
-        uses: actions/setup-node@v6.3.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: npm
-          cache-dependency-path: docs/package-lock.json
 
-      - name: Install documentation dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: npm install
         working-directory: docs
 
       - name: Replace generated CLI docs
@@ -66,6 +64,6 @@ jobs:
           rm -rf docs/content/pages/docs/cli/manual/zoo*.md
           mv -f generated_docs/md/zoo*.md docs/content/pages/docs/cli/manual/
 
-      - name: Build documentation
+      - name: Run build
         run: npm run build
         working-directory: docs

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 # For this to work, you need to install toml-cli: https://github.com/gnprice/toml-cli
 # `cargo install toml-cli`
-VERSION := $(shell toml get $(CURDIR)/Cargo.toml package.version | jq -r .)
+VERSION = $(shell toml get $(CURDIR)/Cargo.toml package.version | jq -r .)
 
 GITCOMMIT := $(shell git rev-parse --short HEAD)
 GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
@@ -116,4 +116,3 @@ __check_defined = \
     $(if $(value $1),, \
     $(error Undefined $1$(if $2, ($2))$(if $(value @), \
     required by target `$@')))
-

--- a/src/docs_markdown.rs
+++ b/src/docs_markdown.rs
@@ -80,8 +80,6 @@ fn do_markdown(doc: &mut MarkdownDocument, app: &Command, title: &str) -> Result
 
         let mut html = "<dl class=\"flags\">\n".to_string();
 
-        println!("{args:#?}");
-
         for (i, arg) in args.iter().enumerate() {
             if i > 0 {
                 html.push('\n');
@@ -109,6 +107,7 @@ fn do_markdown(doc: &mut MarkdownDocument, app: &Command, title: &str) -> Result
                 .get_long_help()
                 .unwrap_or_else(|| arg.get_help().unwrap_or_default())
                 .to_string();
+            desc = normalize_description_for_definition_list(&desc);
 
             // Check if the arg is an enum and if so, add the possible values.
             let possible_values = arg.get_possible_values();
@@ -121,10 +120,6 @@ fn do_markdown(doc: &mut MarkdownDocument, app: &Command, title: &str) -> Result
                     desc.push_str(value.get_name());
                 }
                 desc.push_str("</code>");
-            }
-
-            if arg.get_long().unwrap_or_default() == "shell" {
-                println!("{arg:?}");
             }
 
             let values = arg.get_default_values();
@@ -229,6 +224,10 @@ fn do_markdown(doc: &mut MarkdownDocument, app: &Command, title: &str) -> Result
     Ok(())
 }
 
+fn normalize_description_for_definition_list(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 fn get_cmark_options() -> pulldown_cmark_to_cmark::Options<'static> {
     pulldown_cmark_to_cmark::Options {
         newlines_after_codeblock: 2,
@@ -292,6 +291,22 @@ pub fn app_to_markdown(app: &Command, title: &str) -> Result<String> {
 mod test {
     use pretty_assertions::assert_eq;
 
+    fn definition_descriptions(markdown: &str) -> Vec<&str> {
+        let mut descriptions = Vec::new();
+        let mut remainder = markdown;
+
+        while let Some(start) = remainder.find("<dd>") {
+            let after_start = &remainder[start + "<dd>".len()..];
+            let Some(end) = after_start.find("</dd>") else {
+                break;
+            };
+            descriptions.push(&after_start[..end]);
+            remainder = &after_start[end + "</dd>".len()..];
+        }
+
+        descriptions
+    }
+
     #[test]
     fn test_rustdoc_to_markdown_link() {
         assert_eq!(
@@ -335,5 +350,35 @@ mod test {
             super::cleanup_code_blocks("```some code\nsome other code```").unwrap(),
             "```\nsome code\nsome other code\n```"
         );
+    }
+
+    #[test]
+    fn test_multiline_arg_description_is_safe_for_mdx_definition_list() {
+        let app = clap::Command::new("delete")
+            .about("Delete one of your uploaded projects.")
+            .arg(
+                clap::Arg::new("id-or-path")
+                    .help(
+                        "The project id, or a local project directory, `.kcl` file, or `project.toml`.\n\n\
+                         When a local path is provided, the persisted Zoo cloud project id will be removed from\n\
+                         `project.toml` after the remote project is deleted.",
+                    )
+                    .required(true),
+            );
+
+        let markdown = super::app_to_markdown(&app, "zoo project delete").unwrap();
+
+        assert!(markdown.contains(
+            "<dd>The project id, or a local project directory, `.kcl` file, or `project.toml`. \
+             When a local path is provided, the persisted Zoo cloud project id will be removed from \
+             `project.toml` after the remote project is deleted.</dd>"
+        ));
+
+        for description in definition_descriptions(&markdown) {
+            assert!(
+                !description.contains('\n'),
+                "definition descriptions must stay inline for MDX: {description:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
- Collapse whitespace inside definition list descriptions so multiline clap help stays inline in `<dd>` tags, add a regression test, and remove stray debug logging.
- Add a workflow that generates CLI markdown, replaces the documentation repo's CLI pages, and builds the site. `VERSION` is now lazily evaluated so `make gen-md` does not require toml-cli during parse time.