### PR TITLE
feat(release): generate Windows install instructions

### DIFF
--- a/.github/workflows/make-cross.yml
+++ b/.github/workflows/make-cross.yml
@@ -8,6 +8,7 @@ on:
       - Cargo.lock
       - .github/workflows/make-cross.yml
       - Makefile
+      - scripts/release-install-instructions.sh
       - 'rust-toolchain.toml'
       - 'spec.json'
   pull_request:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           ls -la
-          echo 'These instructions are meant as an easy way to install. Note: you likely need to install `coreutils` in order to have the `sha256sum` command.' > release.md
+          echo 'These instructions are meant as an easy way to install. Unix snippets use `sha256sum`; macOS users may need `coreutils` for that command.' > release.md
           echo "" >> release.md
           cat macos-latest-${{github.ref_name}}-README.md  \
             ubuntu-latest-${{github.ref_name}}-README.md \

--- a/.github/workflows/windows-install-directions.yml
+++ b/.github/workflows/windows-install-directions.yml
@@ -1,0 +1,61 @@
+name: windows install directions
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+      - .github/workflows/make-release.yml
+      - .github/workflows/windows-install-directions.yml
+      - Makefile
+      - scripts/release-install-instructions.sh
+      - scripts/test-windows-install-directions.ps1
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/make-release.yml
+      - .github/workflows/windows-install-directions.yml
+      - Makefile
+      - scripts/release-install-instructions.sh
+      - scripts/test-windows-install-directions.ps1
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  install:
+    name: install from generated directions
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install latest rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache cargo registry
+        uses: actions/cache@v5.0.5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v5.0.5
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v5.0.5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Windows binary
+        run: cargo build --locked --bin zoo
+      - name: Test generated install directions
+        shell: pwsh
+        run: ./scripts/test-windows-install-directions.ps1 -BinaryPath ./target/debug/zoo.exe

--- a/.github/workflows/windows-install-directions.yml
+++ b/.github/workflows/windows-install-directions.yml
@@ -38,7 +38,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - name: Cache cargo registry
         uses: actions/cache@v5.0.5
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7341,7 +7341,7 @@ checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
 
 [[package]]
 name = "zoo"
-version = "0.2.163"
+version = "0.2.164"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zoo"
-version = "0.2.163"
+version = "0.2.164"
 edition = "2021"
 build = "build.rs"
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ NAME := zoo
 BUILDDIR := ${PREFIX}/cross
 
 GENERATED_DOCS_DIR := ${PREFIX}/generated_docs
+DOWNLOAD_BASE_URL ?= https://dl.zoo.dev/releases/cli
 
 UNAME := $(shell uname)
 
@@ -46,18 +47,12 @@ cargo build --release --target $(1) || cross build --release --target $(1)
 mv $(CURDIR)/target/$(1)/release/$(NAME) $(BUILDDIR)/$(NAME)-$(1) || mv $(CURDIR)/target/$(1)/release/$(NAME).exe $(BUILDDIR)/$(NAME)-$(1)
 md5sum $(BUILDDIR)/$(NAME)-$(1) > $(BUILDDIR)/$(NAME)-$(1).md5;
 sha256sum $(BUILDDIR)/$(NAME)-$(1) > $(BUILDDIR)/$(NAME)-$(1).sha256;
-echo -e "### $(1)\n\n" >> $(BUILDDIR)/README.md;
-echo -e "\`\`\`console" >> $(BUILDDIR)/README.md;
-echo -e "# Export the sha256sum for verification." >> $(BUILDDIR)/README.md;
-echo -e "$$ export ZOO_CLI_SHA256=\"`cat $(BUILDDIR)/$(NAME)-$(1).sha256 | awk '{print $$1}'`\"\n\n" >> $(BUILDDIR)/README.md;
-echo -e "# Download and check the sha256sum." >> $(BUILDDIR)/README.md;
-echo -e "$$ curl -fSL \"https://dl.zoo.dev/releases/cli/v$(VERSION)/$(NAME)-$(1)\" -o \"/usr/local/bin/$(NAME)\" \\" >> $(BUILDDIR)/README.md;
-echo -e "\t&& echo \"\$${ZOO_CLI_SHA256}  /usr/local/bin/$(NAME)\" | sha256sum -c - \\" >> $(BUILDDIR)/README.md;
-echo -e "\t&& chmod a+x \"/usr/local/bin/$(NAME)\"\n\n" >> $(BUILDDIR)/README.md;
-echo -e "$$ echo \"$(NAME) cli installed!\"\n" >> $(BUILDDIR)/README.md;
-echo -e "# Run it!" >> $(BUILDDIR)/README.md;
-echo -e "$$ $(NAME) -h" >> $(BUILDDIR)/README.md;
-echo -e "\`\`\`\n\n" >> $(BUILDDIR)/README.md;
+bash $(CURDIR)/scripts/release-install-instructions.sh \
+	"$(1)" \
+	"v$(VERSION)" \
+	"$(NAME)" \
+	"$$(awk '{print $$1}' $(BUILDDIR)/$(NAME)-$(1).sha256)" \
+	"$(DOWNLOAD_BASE_URL)" >> $(BUILDDIR)/README.md;
 endef
 
 # If running on a Mac you will need:

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1778151388,
+        "narHash": "sha256-lldMJPUeouEjO8/7aLuwhcsIw29vVihm2ZALzjiqfec=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "efdddff9ff4d8e7d0056d57ec67dac50f75ab8f6",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775095191,
-        "narHash": "sha256-CsqRiYbgQyv01LS0NlC7shwzhDhjNDQSrhBX8VuD3nM=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "106eb93cbb9d4e4726bf6bc367a3114f7ed6b32f",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1775099554,
-        "narHash": "sha256-3xBsGnGDLOFtnPZ1D3j2LU19wpAlYefRKTlkv648rU0=",
+        "lastModified": 1778210054,
+        "narHash": "sha256-iYINsX0BVDxTXd0z4FzDpBYHZ9fWUtwjG9cKSXwe9Tg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8d6387ed6d8e6e6672fd3ed4b61b59d44b124d99",
+        "rev": "bc83d66023d19fb301ee98772643b24b6129ef48",
         "type": "github"
       },
       "original": {

--- a/scripts/release-install-instructions.sh
+++ b/scripts/release-install-instructions.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 4 || $# -gt 5 ]]; then
+	echo "usage: $0 <target> <version> <name> <sha256> [download-base-url]" >&2
+	exit 2
+fi
+
+target=$1
+version=$2
+name=$3
+sha256=$4
+download_base_url=${5:-${ZOO_CLI_DOWNLOAD_BASE_URL:-https://dl.zoo.dev/releases/cli}}
+download_base_url=${download_base_url%/}
+download_url="${download_base_url}/${version}/${name}-${target}"
+
+cat <<EOF
+### ${target}
+
+EOF
+
+case "${target}" in
+	*-pc-windows-*)
+		cat <<EOF
+\`\`\`powershell
+# Export the sha256sum for verification.
+\$ZOO_CLI_SHA256 = "${sha256}"
+
+# Define where to install the Zoo CLI.
+\$zooPath = Join-Path \$env:LOCALAPPDATA "Zoo"
+\$cliPath = Join-Path \$zooPath "zoo.exe"
+
+# Create the directory for the Zoo CLI.
+New-Item -ItemType Directory -Force -Path \$zooPath | Out-Null
+
+# Download and check the sha256sum.
+Invoke-WebRequest -Uri "${download_url}" -OutFile \$cliPath
+\$actualHash = (Get-FileHash -Algorithm SHA256 \$cliPath).Hash.ToLowerInvariant()
+if (\$actualHash -ne \$ZOO_CLI_SHA256.ToLowerInvariant()) {
+    throw "Checksum verification failed for \$cliPath"
+}
+
+function Test-PathContains {
+    param(
+        [string]\$PathValue,
+        [string]\$Directory
+    )
+
+    if ([string]::IsNullOrWhiteSpace(\$PathValue)) {
+        return \$false
+    }
+
+    \$directoryToFind = \$Directory.TrimEnd('\')
+    foreach (\$entry in \$PathValue -split ';') {
+        if (\$entry.TrimEnd('\') -ieq \$directoryToFind) {
+            return \$true
+        }
+    }
+
+    return \$false
+}
+
+# Add the Zoo CLI directory to your user Path if needed.
+\$userPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User)
+if (-not (Test-PathContains -PathValue \$userPath -Directory \$zooPath)) {
+    \$pathEntries = @()
+    if (-not [string]::IsNullOrWhiteSpace(\$userPath)) {
+        \$pathEntries = \$userPath -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace(\$_) }
+    }
+    \$pathEntries += \$zooPath
+    [Environment]::SetEnvironmentVariable("Path", (\$pathEntries -join ';'), [EnvironmentVariableTarget]::User)
+}
+
+# Make the new Path available in this PowerShell session.
+if (-not (Test-PathContains -PathValue \$env:Path -Directory \$zooPath)) {
+    \$env:Path = ((@(\$env:Path, \$zooPath) | Where-Object { -not [string]::IsNullOrWhiteSpace(\$_) }) -join ';')
+}
+
+Write-Host "${name} cli installed!"
+
+# Run it!
+${name} -h
+\`\`\`
+
+EOF
+		;;
+	*)
+		cat <<EOF
+\`\`\`console
+# Export the sha256sum for verification.
+\$ export ZOO_CLI_SHA256="${sha256}"
+
+
+# Download and check the sha256sum.
+\$ curl -fSL "${download_url}" -o "/usr/local/bin/${name}" \\
+	&& echo "\${ZOO_CLI_SHA256}  /usr/local/bin/${name}" | sha256sum -c - \\
+	&& chmod a+x "/usr/local/bin/${name}"
+
+
+\$ echo "${name} cli installed!"
+
+# Run it!
+\$ ${name} -h
+\`\`\`
+
+EOF
+		;;
+esac

--- a/scripts/test-windows-install-directions.ps1
+++ b/scripts/test-windows-install-directions.ps1
@@ -194,6 +194,9 @@ try {
     }
 
     $installScript = Get-PowerShellBlock -Markdown ($instructions -join "`n")
+    if ($installScript -notmatch '\[EnvironmentVariableTarget\]::User') {
+        throw "Windows instructions do not persist the Zoo CLI directory to the user Path"
+    }
     Set-Content -Path (Join-Path $testRoot "install.ps1") -Value $installScript -Encoding utf8
 
     $testLocalAppData = Join-Path $testRoot "local-app-data"
@@ -217,8 +220,6 @@ try {
         throw "installed binary hash mismatch"
     }
 
-    $userPathAfterInstall = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User)
-    Assert-PathEntryCount -PathValue $userPathAfterInstall -Directory $installDir -ExpectedCount 1
     Assert-PathEntryCount -PathValue $env:Path -Directory $installDir -ExpectedCount 1
 
     & $installedCli -h | Out-Null

--- a/scripts/test-windows-install-directions.ps1
+++ b/scripts/test-windows-install-directions.ps1
@@ -93,7 +93,7 @@ function Wait-ForArtifact {
 function Get-PowerShellBlock {
     param([string]$Markdown)
 
-    $match = [regex]::Match($Markdown, "(?s)```powershell\r?\n(?<script>.*?)\r?\n```")
+    $match = [regex]::Match($Markdown, '(?s)```powershell\r?\n(?<script>.*?)\r?\n```')
     if (-not $match.Success) {
         throw "generated instructions did not contain a PowerShell code block"
     }

--- a/scripts/test-windows-install-directions.ps1
+++ b/scripts/test-windows-install-directions.ps1
@@ -1,0 +1,240 @@
+[CmdletBinding()]
+param(
+    [string]$BinaryPath = (Join-Path (Get-Location) "target/debug/zoo.exe"),
+    [string]$Target = "x86_64-pc-windows-gnu",
+    [string]$Name = "zoo",
+    [string]$Version = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-LastExitCode {
+    param([string]$CommandName)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$CommandName failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-FreeTcpPort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        return $listener.LocalEndpoint.Port
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
+function Get-PythonCommand {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        return @{
+            FilePath = $python.Source
+            PrefixArgs = @()
+        }
+    }
+
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        return @{
+            FilePath = $py.Source
+            PrefixArgs = @("-3")
+        }
+    }
+
+    throw "python is required to serve the local release artifact"
+}
+
+function Get-CargoPackageVersion {
+    param(
+        [string]$PackageName,
+        [string]$ManifestPath
+    )
+
+    $metadataJson = & cargo metadata --manifest-path $ManifestPath --no-deps --format-version 1
+    Assert-LastExitCode "cargo metadata"
+
+    $metadata = $metadataJson | ConvertFrom-Json
+    $package = $metadata.packages | Where-Object { $_.name -eq $PackageName } | Select-Object -First 1
+    if (-not $package) {
+        throw "could not find package '$PackageName' in cargo metadata"
+    }
+
+    return $package.version
+}
+
+function Wait-ForArtifact {
+    param(
+        [string]$Uri,
+        [string]$ServerStdout,
+        [string]$ServerStderr
+    )
+
+    for ($attempt = 0; $attempt -lt 60; $attempt++) {
+        try {
+            $response = Invoke-WebRequest -Uri $Uri -Method Head -TimeoutSec 2
+            if ($response.StatusCode -eq 200) {
+                return
+            }
+        }
+        catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+
+    $stdout = if (Test-Path $ServerStdout) { Get-Content $ServerStdout -Raw } else { "" }
+    $stderr = if (Test-Path $ServerStderr) { Get-Content $ServerStderr -Raw } else { "" }
+    throw "local artifact server did not serve $Uri`nstdout:`n$stdout`nstderr:`n$stderr"
+}
+
+function Get-PowerShellBlock {
+    param([string]$Markdown)
+
+    $match = [regex]::Match($Markdown, "(?s)```powershell\r?\n(?<script>.*?)\r?\n```")
+    if (-not $match.Success) {
+        throw "generated instructions did not contain a PowerShell code block"
+    }
+
+    return $match.Groups["script"].Value
+}
+
+function Assert-PathEntryCount {
+    param(
+        [string]$PathValue,
+        [string]$Directory,
+        [int]$ExpectedCount
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        $PathValue = ""
+    }
+
+    $normalizedDirectory = $Directory.TrimEnd('\')
+    $matches = @(
+        $PathValue -split ';' |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Where-Object { $_.TrimEnd('\') -ieq $normalizedDirectory }
+    )
+
+    if ($matches.Count -ne $ExpectedCount) {
+        throw "expected $Directory to appear in Path $ExpectedCount time(s), found $($matches.Count)"
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$renderScript = Join-Path $repoRoot "scripts/release-install-instructions.sh"
+if (-not (Test-Path $renderScript)) {
+    throw "missing release instructions renderer: $renderScript"
+}
+
+if (-not (Test-Path $BinaryPath)) {
+    throw "missing binary to install: $BinaryPath"
+}
+$binaryPath = (Resolve-Path $BinaryPath).Path
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = "v$(Get-CargoPackageVersion -PackageName $Name -ManifestPath (Join-Path $repoRoot "Cargo.toml"))"
+}
+elseif (-not $Version.StartsWith("v")) {
+    $Version = "v$Version"
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "zoo-install-directions-$([System.Guid]::NewGuid())"
+$releaseRoot = Join-Path $testRoot "release-root"
+$versionDir = Join-Path (Join-Path (Join-Path $releaseRoot "releases") "cli") $Version
+$releaseBinary = Join-Path $versionDir "$Name-$Target"
+$serverStdout = Join-Path $testRoot "http.out.log"
+$serverStderr = Join-Path $testRoot "http.err.log"
+$server = $null
+$originalLocalAppData = $env:LOCALAPPDATA
+$originalProcessPath = $env:Path
+$originalUserPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User)
+
+try {
+    New-Item -ItemType Directory -Force -Path $versionDir | Out-Null
+    Copy-Item -Force -Path $binaryPath -Destination $releaseBinary
+    $expectedHash = (Get-FileHash -Algorithm SHA256 $releaseBinary).Hash.ToLowerInvariant()
+
+    $port = Get-FreeTcpPort
+    $pythonCommand = Get-PythonCommand
+    $serverArgs = @($pythonCommand.PrefixArgs) + @(
+        "-m",
+        "http.server",
+        [string]$port,
+        "--bind",
+        "127.0.0.1"
+    )
+    $server = Start-Process `
+        -FilePath $pythonCommand.FilePath `
+        -ArgumentList $serverArgs `
+        -WorkingDirectory $releaseRoot `
+        -PassThru `
+        -RedirectStandardOutput $serverStdout `
+        -RedirectStandardError $serverStderr
+
+    $baseUrl = "http://127.0.0.1:$port/releases/cli"
+    $artifactUrl = "$baseUrl/$Version/$Name-$Target"
+    Wait-ForArtifact -Uri $artifactUrl -ServerStdout $serverStdout -ServerStderr $serverStderr
+
+    $bash = Get-Command bash -ErrorAction SilentlyContinue
+    if (-not $bash) {
+        throw "bash is required to render the release install instructions"
+    }
+
+    $instructions = & $($bash.Source) $renderScript $Target $Version $Name $expectedHash $baseUrl
+    Assert-LastExitCode "release install instruction rendering"
+    $instructionsPath = Join-Path $testRoot "README.md"
+    Set-Content -Path $instructionsPath -Value $instructions -Encoding utf8
+
+    if ($instructions -match "/usr/local/bin|chmod|sha256sum -c") {
+        throw "Windows instructions still contain Unix install commands"
+    }
+
+    $installScript = Get-PowerShellBlock -Markdown ($instructions -join "`n")
+    Set-Content -Path (Join-Path $testRoot "install.ps1") -Value $installScript -Encoding utf8
+
+    $testLocalAppData = Join-Path $testRoot "local-app-data"
+    New-Item -ItemType Directory -Force -Path $testLocalAppData | Out-Null
+
+    $env:LOCALAPPDATA = $testLocalAppData
+    $env:Path = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine)
+    [Environment]::SetEnvironmentVariable("Path", (Join-Path $testRoot "user-bin"), [EnvironmentVariableTarget]::User)
+
+    Invoke-Expression $installScript
+    Invoke-Expression $installScript
+
+    $installDir = Join-Path $testLocalAppData "Zoo"
+    $installedCli = Join-Path $installDir "zoo.exe"
+    if (-not (Test-Path $installedCli)) {
+        throw "install instructions did not create $installedCli"
+    }
+
+    $installedHash = (Get-FileHash -Algorithm SHA256 $installedCli).Hash.ToLowerInvariant()
+    if ($installedHash -ne $expectedHash) {
+        throw "installed binary hash mismatch"
+    }
+
+    $userPathAfterInstall = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User)
+    Assert-PathEntryCount -PathValue $userPathAfterInstall -Directory $installDir -ExpectedCount 1
+    Assert-PathEntryCount -PathValue $env:Path -Directory $installDir -ExpectedCount 1
+
+    & $installedCli -h | Out-Null
+    Assert-LastExitCode "$installedCli -h"
+
+    & $Name -h | Out-Null
+    Assert-LastExitCode "$Name -h from Path"
+
+    Write-Host "Windows install instructions installed $Name from $artifactUrl"
+}
+finally {
+    $env:LOCALAPPDATA = $originalLocalAppData
+    $env:Path = $originalProcessPath
+    [Environment]::SetEnvironmentVariable("Path", $originalUserPath, [EnvironmentVariableTarget]::User)
+
+    if ($server -and -not $server.HasExited) {
+        Stop-Process -Id $server.Id -Force
+    }
+}


### PR DESCRIPTION
- Render install snippets through a shared script, including PowerShell directions with checksum validation and user Path setup.
- Add CI that builds a Windows binary and runs the generated directions against a local release artifact.

closes https://github.com/KittyCAD/cli/issues/60