### PR TITLE
fix clippy make ci faster

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -54,15 +54,7 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run cargo test
-        run: |
-          cargo nextest run --workspace
-        env:
-          ZOO_TEST_TOKEN: ${{secrets.KITTYCAD_TOKEN}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          RUST_BACKTRACE: 1
-
-      - name: Test with coverage
+      - name: Run tests with coverage
         run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --no-fail-fast
         env:
           ZOO_TEST_TOKEN: ${{secrets.KITTYCAD_TOKEN}}

--- a/src/cmd_kcl.rs
+++ b/src/cmd_kcl.rs
@@ -1918,8 +1918,10 @@ mod tests {
 
     #[test]
     fn with_heartbeats_preserves_explicit_setting() {
-        let mut settings = kcl_lib::ExecutorSettings::default();
-        settings.heartbeats = Some(17);
+        let settings = kcl_lib::ExecutorSettings {
+            heartbeats: Some(17),
+            ..Default::default()
+        };
 
         let settings = with_heartbeats(settings);
 


### PR DESCRIPTION
- Let cargo llvm-cov nextest be the single test runner that emits lcov.
- Build heartbeat test settings directly instead of mutating defaults.