### PR TITLE
(build) sets 1.95 as minimum supported and uses 1.95 for builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zoo"
 version = "0.2.172"
 edition = "2021"
+rust-version = "1.95"
 build = "build.rs"
 
 [workspace]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION

* Cargo.toml sets minimum supported Rust version 
* rust-toolchain.toml sets exact version to use for dev and ci

This PR sets both files to 1.95