### PR TITLE
build(nix): replace naersk with rustPlatform packaging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,63 +1,6 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "naersk",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1752475459,
-        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1778151388,
-        "narHash": "sha256-lldMJPUeouEjO8/7aLuwhcsIw29vVihm2ZALzjiqfec=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "efdddff9ff4d8e7d0056d57ec67dac50f75ab8f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1778124196,
         "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
@@ -73,7 +16,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -91,31 +34,13 @@
     },
     "root": {
       "inputs": {
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752428706,
-        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1778210054,

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    naersk.url = "github:nix-community/naersk";
   };
 
   outputs = {
     self,
     nixpkgs,
     rust-overlay,
-    naersk,
   }: let
     overlays = [
       (import rust-overlay)
@@ -68,37 +66,26 @@
       pkgs,
       system,
     }: let
-      fetchCrate = args:
-        let
-          crateMatch =
-            if args ? url && builtins.isString args.url
-            then builtins.match "https://crates.io/api/v1/crates/([^/]+)/([^/]+)/download" args.url
-            else null;
-        in
-          pkgs.fetchurl (args
-            // (
-              if crateMatch == null
-              then {}
-              else {
-                url = let
-                  name = builtins.elemAt crateMatch 0;
-                  version = builtins.elemAt crateMatch 1;
-                in "https://static.crates.io/crates/${name}/${name}-${version}.crate";
-              }
-            ));
-      naersk-lib = pkgs.callPackage naersk {
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      rustPlatform = pkgs.makeRustPlatform {
         cargo = pkgs.rustToolchain;
-        fetchurl = fetchCrate;
         rustc = pkgs.rustToolchain;
       };
     in {
-      zoo = naersk-lib.buildPackage {
+      zoo = rustPlatform.buildRustPackage {
         pname = "zoo";
-        version = "0.1.0";
-        release = true;
+        version = cargoToml.package.version;
         src = ./.;
 
-        buildInputs = [pkgs.openssl pkgs.pkg-config];
+        cargoLock = {
+          lockFile = ./Cargo.lock;
+          outputHashes = {
+            "openapitor-0.0.9" = "sha256-YRLglTUCrXyoajZK2v9FpHUVsD3ugPQwliwFGs/47Z0=";
+          };
+        };
+
+        nativeBuildInputs = [pkgs.pkg-config];
+        buildInputs = [pkgs.openssl];
       };
       default = self.packages.${system}.zoo;
     });

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
           };
         };
 
+        doCheck = false;
         nativeBuildInputs = [pkgs.pkg-config];
         buildInputs = [pkgs.openssl];
       };


### PR DESCRIPTION
- Build with buildRustPackage and read the version from Cargo.toml.
- Drop naersk, fenix, and rust-analyzer inputs from the flake lock.