### PR TITLE
Fix tests to fail when there are failures

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1231,4 +1231,9 @@ async fn test_main(ctx: &mut MainContext) {
         eprintln!("Test '{}' failed:\n{}", test_error.name, test_error.reason);
     }
     eprintln!("Failed {failed} tests, passed {passed}, skipped {skipped}");
+    assert_eq!(failed, 0, "There should have been zero failures.");
+    assert!(
+        passed > 0,
+        "There should have been at least one passing test. passed={passed}, skipped={skipped}"
+    );
 }


### PR DESCRIPTION
Don't merge this.

13 tests are failing on `main`. The problem of not failing CI on failing tests was introduced in #1305.

This PR is intended to be proof that `main` is busted, and we should fix the tests up and split them up using:

- #1527