### PR TITLE
Fix tests on split tests branch

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage
-        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --retries=3 --lcov --output-path lcov.info --no-fail-fast
         env:
           ZOO_TEST_TOKEN: ${{secrets.KITTYCAD_TOKEN}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage
-        run: cargo llvm-cov nextest --workspace --retries=3 --lcov --output-path lcov.info --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --no-fail-fast
         env:
           ZOO_TEST_TOKEN: ${{secrets.KITTYCAD_TOKEN}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, time::Duration};
+use std::{io::Write, str::FromStr, time::Duration};
 
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
@@ -353,7 +353,7 @@ impl Context<'_> {
     }
 
     pub async fn get_model_for_prompt(
-        &self,
+        &mut self,
         hostname: &str,
         prompt: &str,
         kcl: bool,
@@ -378,10 +378,9 @@ impl Context<'_> {
             .await?;
 
         // Start reasoning websocket to stream reasoning messages for this generation.
-        let reasoning_guard = ReasoningGuard::new(
-            self.spawn_reasoning_ws_task(&client, gen_model.id, show_reasoning)
-                .await,
-        );
+        let mut reasoning_guard = self
+            .spawn_reasoning_ws_task(&client, gen_model.id, show_reasoning)
+            .await;
 
         // Poll until the model is ready.
         let mut status = gen_model.status.clone();
@@ -439,11 +438,16 @@ impl Context<'_> {
                 anyhow::bail!("Unexpected response type: {result:?}");
             }
 
+            reasoning_guard.drain(&mut self.io.err_out)?;
             status = gen_model.status.clone();
 
             // Wait for a bit before polling again.
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            reasoning_guard.drain(&mut self.io.err_out)?;
         }
+
+        // Flush reasoning output before returning success or surfacing a terminal error.
+        reasoning_guard.finish(&mut self.io.err_out).await?;
 
         // If the model failed we will want to tell the user.
         if gen_model.status == ApiCallStatus::Failed {
@@ -458,13 +462,11 @@ impl Context<'_> {
             anyhow::bail!("Your prompt timed out");
         }
 
-        // Okay, we successfully got a model! Ensure the guard finishes before returning.
-        reasoning_guard.finish().await;
         Ok(gen_model)
     }
 
     pub async fn get_edit_for_prompt(
-        &self,
+        &mut self,
         hostname: &str,
         body: &kittycad::types::TextToCadMultiFileIterationBody,
         files: Vec<kittycad::types::multipart::Attachment>,
@@ -477,10 +479,9 @@ impl Context<'_> {
 
         // Start reasoning websocket to stream reasoning messages for this edit.
         // default to showing reasoning for edits as well; caller can pass false by wrapping here if needed later
-        let reasoning_guard = ReasoningGuard::new(
-            self.spawn_reasoning_ws_task(&client, gen_model.id, show_reasoning)
-                .await,
-        );
+        let mut reasoning_guard = self
+            .spawn_reasoning_ws_task(&client, gen_model.id, show_reasoning)
+            .await;
 
         // Poll until the model is ready.
         let mut status = gen_model.status.clone();
@@ -538,11 +539,16 @@ impl Context<'_> {
                 anyhow::bail!("Unexpected response type: {result:?}");
             }
 
+            reasoning_guard.drain(&mut self.io.err_out)?;
             status = gen_model.status.clone();
 
             // Wait for a bit before polling again.
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            reasoning_guard.drain(&mut self.io.err_out)?;
         }
+
+        // Flush reasoning output before returning success or surfacing a terminal error.
+        reasoning_guard.finish(&mut self.io.err_out).await?;
 
         // If the model failed we will want to tell the user.
         if gen_model.status == ApiCallStatus::Failed {
@@ -557,8 +563,6 @@ impl Context<'_> {
             anyhow::bail!("Your prompt timed out");
         }
 
-        // Okay, we successfully got a model! Ensure the guard finishes before returning.
-        reasoning_guard.finish().await;
         Ok(gen_model)
     }
 
@@ -745,20 +749,16 @@ impl Context<'_> {
 }
 
 impl Context<'_> {
-    async fn spawn_reasoning_ws_task(
-        &self,
-        client: &kittycad::Client,
-        id: uuid::Uuid,
-        enable: bool,
-    ) -> Option<tokio::task::JoinHandle<()>> {
+    async fn spawn_reasoning_ws_task(&self, client: &kittycad::Client, id: uuid::Uuid, enable: bool) -> ReasoningGuard {
         if !enable {
-            return None;
+            return ReasoningGuard::default();
         }
 
         match client.ml().reasoning_ws(id).await {
             Ok((upgraded, _headers)) => {
                 let use_color = self.io.color_enabled() && self.io.is_stderr_tty();
-                Some(tokio::spawn(async move {
+                let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+                let handle = tokio::spawn(async move {
                     let mut ws = WebSocketStream::from_raw_socket(upgraded, Role::Client, None).await;
                     while let Some(msg) = ws.next().await {
                         let Ok(msg) = msg else { break };
@@ -769,10 +769,14 @@ impl Context<'_> {
                             {
                                 match server_msg {
                                     kittycad::types::MlCopilotServerMessage::Reasoning(reason) => {
-                                        print_reasoning(reason, use_color);
+                                        for line in format_reasoning(reason, use_color) {
+                                            if sender.send(line).is_err() {
+                                                break;
+                                            }
+                                        }
                                     }
                                     kittycad::types::MlCopilotServerMessage::Error { detail } => {
-                                        print_copilot_error(&detail, use_color);
+                                        let _ = sender.send(format_copilot_error(&detail, use_color));
                                         // Do not break: errors may be non-fatal; keep streaming.
                                     }
                                     kittycad::types::MlCopilotServerMessage::EndOfStream { .. } => {
@@ -786,42 +790,55 @@ impl Context<'_> {
                         }
                     }
                     let _ = ws.close(None).await;
-                }))
+                });
+                ReasoningGuard::new(handle, receiver)
             }
             Err(err) => {
                 let _ = err; // suppress unused warning; intentionally silent
-                None
+                ReasoningGuard::default()
             }
         }
-    }
-}
-
-// Print only reasoning messages in a friendly, concise CLI format.
-pub(crate) fn print_reasoning(reason: kittycad::types::ReasoningMessage, use_color: bool) {
-    for line in format_reasoning(reason, use_color) {
-        eprintln!("{line}");
     }
 }
 
 // RAII guard to ensure the reasoning websocket task is cancelled and joined.
-struct ReasoningGuard(Option<tokio::task::JoinHandle<()>>);
+#[derive(Default)]
+struct ReasoningGuard {
+    handle: Option<tokio::task::JoinHandle<()>>,
+    receiver: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
+}
 
 impl ReasoningGuard {
-    fn new(handle: Option<tokio::task::JoinHandle<()>>) -> Self {
-        ReasoningGuard(handle)
+    fn new(handle: tokio::task::JoinHandle<()>, receiver: tokio::sync::mpsc::UnboundedReceiver<String>) -> Self {
+        Self {
+            handle: Some(handle),
+            receiver: Some(receiver),
+        }
     }
 
-    async fn finish(mut self) {
-        if let Some(handle) = self.0.take() {
+    fn drain(&mut self, err_out: &mut dyn Write) -> Result<()> {
+        let Some(receiver) = &mut self.receiver else {
+            return Ok(());
+        };
+        while let Ok(line) = receiver.try_recv() {
+            writeln!(err_out, "{line}")?;
+        }
+        Ok(())
+    }
+
+    async fn finish(mut self, err_out: &mut dyn Write) -> Result<()> {
+        self.drain(err_out)?;
+        if let Some(handle) = self.handle.take() {
             handle.abort();
             let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
         }
+        self.drain(err_out)
     }
 }
 
 impl Drop for ReasoningGuard {
     fn drop(&mut self) {
-        if let Some(handle) = self.0.take() {
+        if let Some(handle) = self.handle.take() {
             handle.abort();
             // Ensure the task is polled to completion in the background.
             tokio::spawn(async move {
@@ -992,12 +1009,12 @@ fn indent_block(s: &str) -> String {
     out
 }
 
-fn print_copilot_error(detail: &str, use_color: bool) {
+fn format_copilot_error(detail: &str, use_color: bool) -> String {
     use nu_ansi_term::Color;
     if use_color {
-        eprintln!("{} {}", Color::Red.paint("ml error:"), detail.trim());
+        format!("{} {}", Color::Red.paint("ml error:"), detail.trim())
     } else {
-        eprintln!("ml error: {}", detail.trim());
+        format!("ml error: {}", detail.trim())
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -358,7 +358,7 @@ impl Context<'_> {
         prompt: &str,
         kcl: bool,
         format: kittycad::types::FileExportFormat,
-        show_reasoning: bool,
+        _show_reasoning: bool,
     ) -> Result<TextToCad> {
         let client = self.api_client(hostname)?;
 
@@ -377,10 +377,9 @@ impl Context<'_> {
             )
             .await?;
 
-        // Start reasoning websocket to stream reasoning messages for this generation.
-        let mut reasoning_guard = self
-            .spawn_reasoning_ws_task(&client, gen_model.id, show_reasoning)
-            .await;
+        // Plain text-to-CAD generation does not currently emit reasoning websocket
+        // messages or an EndOfStream marker. KCL edits still stream reasoning through
+        // get_edit_for_prompt.
 
         // Poll until the model is ready.
         let mut status = gen_model.status.clone();
@@ -438,16 +437,11 @@ impl Context<'_> {
                 anyhow::bail!("Unexpected response type: {result:?}");
             }
 
-            reasoning_guard.drain(&mut self.io.err_out)?;
             status = gen_model.status.clone();
 
             // Wait for a bit before polling again.
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            reasoning_guard.drain(&mut self.io.err_out)?;
         }
-
-        // Flush reasoning output before returning success or surfacing a terminal error.
-        reasoning_guard.finish(&mut self.io.err_out).await?;
 
         // If the model failed we will want to tell the user.
         if gen_model.status == ApiCallStatus::Failed {
@@ -828,9 +822,16 @@ impl ReasoningGuard {
 
     async fn finish(mut self, err_out: &mut dyn Write) -> Result<()> {
         self.drain(err_out)?;
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-            let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        if let Some(mut handle) = self.handle.take() {
+            // KCL edit streams should finish by sending `EndOfStream`, so give
+            // the task a short chance to drain final messages. Text-to-CAD
+            // generation showed that not every endpoint closes the reasoning
+            // stream, so this remains a brief best-effort grace period.
+            if tokio::time::timeout(Duration::from_secs(1), &mut handle).await.is_err() {
+                self.drain(err_out)?;
+                handle.abort();
+                let _ = handle.await;
+            }
         }
         self.drain(err_out)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -390,7 +390,6 @@ cli_tests! {
         )
         .setup(setup_authenticated)
         .stdout_contains("Completed")
-        .stderr_contains("reasoning:")
     }
 
     ml_text_to_cad_export_no_reasoning(_ctx) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -801,7 +801,7 @@ cli_tests! {
             ],
         )
         .setup(setup_authenticated)
-        .stdout_contains("74.052")
+        .stdout_contains("74.023")
     }
 
     get_the_mass_of_a_kcl_file_with_nested_dirs_and_a_project_toml(_ctx) => {
@@ -822,7 +822,7 @@ cli_tests! {
             ],
         )
         .setup(setup_authenticated)
-        .stdout_contains("74.052")
+        .stdout_contains("74.023")
     }
 
     analyze_a_kcl_file_as_table(_ctx) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -246,6 +246,8 @@ fn setup_aliases(config: &mut TestConfig, ctx: &MainContext) -> Result<()> {
 fn make_single_file_edit_project() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("failed to create temp dir");
     std::fs::copy("tests/gear.kcl", tmp.path().join("gear.kcl")).expect("copy gear.kcl");
+    // TODO: Fix it so we don't need this temp file.
+    std::fs::write(tmp.path().join("main.kcl"), "cube(1)\n").expect("write main.kcl");
     tmp
 }
 


### PR DESCRIPTION
...even those that were broken on main.

Stacked on #1527.

See #1694 to see how tests were broken on `main`. With this PR, we get both fixed tests and splitting the big test up.

### Implementation

The ml code was writing directly to STDERR using `eprintln!()`. But tests assume that all I/O is captured. So test assertions weren't finding the "reasoning:" in the string.

But... creating a model using `zoo ml text-to-cad export` doesn't output reasoning. So that assertion needed to be removed. (Reasoning is output for `zoo ml kcl edit`.)