### PR TITLE
Don't print KCL source if source range is empty

### DIFF
--- a/src/kcl_error_fmt.rs
+++ b/src/kcl_error_fmt.rs
@@ -1,7 +1,21 @@
 pub(crate) fn into_miette(error: kcl_lib::KclErrorWithOutputs, code: &str) -> anyhow::Error {
+    let inner_err = &error.error;
+    if is_nonsense_source_range(inner_err) {
+        return anyhow::anyhow!("{}", inner_err.get_message());
+    }
     let report = error.clone().into_miette_report_with_outputs(code).unwrap();
     let report = miette::Report::new(report);
     anyhow::anyhow!("{report:?}")
+}
+
+/// Sometimes the KCL runtime doesn't have a good source range, because some error
+/// is not really about a single KCL function. For example, missing auth or not
+/// being able to connect to the engine at all.
+///
+/// This detects those circumstances. If true, you probably shouldn't format the error
+/// with miette + KCL source, because the error isn't really about any particular KCL line.
+fn is_nonsense_source_range(error: &kcl_lib::KclError) -> bool {
+    error.source_ranges().is_empty() || error.source_ranges() == vec![Default::default()]
 }
 
 pub(crate) fn into_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError) -> anyhow::Error {
@@ -38,6 +52,7 @@ pub(crate) fn check_exec_state_issues(
     state: &kcl_lib::ExecState,
     issue_check: KclIssueCheck,
 ) -> anyhow::Result<()> {
+    dbg!();
     check_compilation_issues(err_out, filename, code, state.issues(), issue_check)
 }
 
@@ -48,6 +63,7 @@ pub(crate) fn check_compilation_issues(
     issues: &[kcl_lib::CompilationIssue],
     issue_check: KclIssueCheck,
 ) -> anyhow::Result<()> {
+    dbg!();
     if issue_check == KclIssueCheck::Ignore || issues.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
If the source range is empty, then Miette will show the error at the very start of the very first line. But that doesn't really make sense, it actually means "there's no real place for this error". So let's not show source code at all.

Here's an example of what it looks like to run `zoo kcl snapshot` if you don't have any auth token set.

Before:
```
KCL Engine error

  × engine: Please send `{ headers: { Authorization: "Bearer <token>" } }` over this websocket.
   ╭─[1:1]
 1 │ @settings(kclVersion = 2.0, defaultLengthUnit = ft)
   · ▲
   · ╰── main
 2 │
   ╰────
```

(the CLI output says the error is from line 0, i.e. the `@settings`, but that's clearly wrong, it's got nothing to do with your KCL settings)

After:
```
engine: Please send `{ headers: { Authorization: "Bearer <token>" } }` over this websocket
```

No misleading text saying that the problem is on line 0.