### PR TITLE
Partition the nextest runs for faster feedback and retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,5 @@
+[profile.ci]
+fail-fast = false
+
 [profile.ci.junit]
 path = "../../../test-results/junit.xml"

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -10,6 +10,7 @@ on:
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/cargo-test.yml
+      - .config/nextest.toml
       - 'rust-toolchain.toml'
       - 'Makefile'
       - 'spec.json'
@@ -26,8 +27,13 @@ concurrency:
 
 jobs:
   cargotest:
-    name: cargo test
+    name: cargo test (shard ${{ matrix.partitionIndex }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partitionIndex: [1, 2, 3, 4, 5]
+        partitionTotal: [5]
     steps:
       - uses: actions/checkout@master
       - name: Install latest rust
@@ -63,7 +69,8 @@ jobs:
       - name: Run tests with coverage
         run: |-
           cargo llvm-cov nextest \
-            --workspace --lcov --output-path lcov.info --no-fail-fast \
+            --workspace --lcov --output-path=lcov.info \
+            --partition=count:${{ matrix.partitionIndex }}/${{ matrix.partitionTotal }} \
             --profile=ci || true  # let TAB determine failure
           .github/workflows/lib/upload-results.sh
         env:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -82,11 +82,30 @@ jobs:
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
 
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-${{ matrix.partitionIndex }}
+          path: lcov.info
+
+  codecov:
+    name: Upload coverage to codecov
+    needs: cargotest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lcov-*
+          path: coverage
+          merge-multiple: false
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
           flags: unittests
-          files: lcov.info
+          directory: coverage
           verbose: true


### PR DESCRIPTION
This should shorten the feedback cycle and make it so we only have to retry a subset of tests.