### PR TITLE
Release 185 and bump kcl

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -71,6 +71,7 @@ jobs:
           cargo llvm-cov nextest \
             --workspace --lcov --output-path=lcov.info \
             --partition=count:${{ matrix.partitionIndex }}/${{ matrix.partitionTotal }} \
+            --retries=5 \
             --profile=ci || true  # let TAB determine failure
           .github/workflows/lib/upload-results.sh
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "kcl-api"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00f918c82e071451c6a1a1603f8870abac34511e77fc1c12b8188b8368eb267"
+checksum = "97a1f74efaa8d3dbffbd48145791b63bd8acbac381704526bd1ca0394f96e5f0"
 dependencies = [
  "indexmap 2.14.0",
  "kcl-error",
@@ -2836,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8105fdc8e9a1074a5737df62cabd3bfefc6d7615c22993f879925ee109f5bf09"
+checksum = "7ce4dc7edd0b2686d745d23112f3c0bc1378e10023a95ae906b5b550bbbffdad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2847,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "kcl-error"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39149a2390900e7ee349fe2ad371f4fe15f8cd6521be7c3554bbffd6d0fa792d"
+checksum = "c0473b9dc6790af3bf15cfb40e9957ed96865a6cdd8b2c42ec6eb73336aa019b"
 dependencies = [
  "miette",
  "schemars 0.8.22",
@@ -2861,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ab14e9952f3b18a295ed4cfdbc6763cf4fe756cf3f68d6de1b6c1aa9cc5b20"
+checksum = "d1bf0feaed8970f877643aca51ee4628d69ed99f145c2c5a13e83960cbf5226f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2918,7 +2918,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "toml 1.1.0+spec-1.1.0",
  "tower-lsp",
  "ts-rs",
@@ -2940,18 +2940,18 @@ dependencies = [
 
 [[package]]
 name = "kcl-syntax"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38abfbf37884f92863ae9d845e31bff42472fabe25c056cb9fa332a60d5a80ae"
+checksum = "857b2cc8ae4e23af0280fdba3b4e259c39112e0ce73b071ed16e6c65fb279218"
 dependencies = [
  "logos",
 ]
 
 [[package]]
 name = "kcl-test-server"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56069e844f9722cc9831bfc80f8d2ae300cb32d3654d8268bd4b4c07d91f35d2"
+checksum = "85a7c158f2688596516d6cba09cb02c474328102cb7657d86934f82010c8f7fe"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.216"
+version = "0.2.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758111ce21d88949e4df265aec15ef78e2d4218faa32ccce132cec70d8b21205"
+checksum = "13fa97ccecf077d08e26a6c4ddc311a9d21547676341fcd1cf6a4fbfb23adf2a"
 dependencies = [
  "anyhow",
  "bon",
@@ -5409,17 +5409,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -6185,9 +6174,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -6196,19 +6185,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
- "tungstenite 0.29.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.30.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -6495,24 +6472,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.2",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls 0.23.26",
- "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 2.0.19",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
@@ -6523,7 +6482,9 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.10.2",
- "sha1 0.11.0",
+ "rustls 0.23.26",
+ "rustls-pki-types",
+ "sha1",
  "thiserror 2.0.19",
 ]
 
@@ -6679,12 +6640,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -7596,7 +7556,7 @@ checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
 
 [[package]]
 name = "zoo"
-version = "0.2.184"
+version = "0.2.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7659,7 +7619,7 @@ dependencies = [
  "test-context",
  "thiserror 2.0.19",
  "tokio",
- "tokio-tungstenite 0.30.0",
+ "tokio-tungstenite",
  "toml 1.1.0+spec-1.1.0",
  "toml_edit 0.25.8+spec-1.1.0",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zoo"
-version = "0.2.184"
+version = "0.2.185"
 edition = "2024"
 rust-version = "1.96"
 build = "build.rs"
@@ -40,16 +40,16 @@ image = { version = "0.25", default-features = false, features = [
   "jpeg",
 ] }
 itertools = "0.15.0"
-kcl-error = "=0.2.170"
-kcl-lib = { version = "=0.2.170", features = ["disable-println"] }
-kcl-test-server = "=0.2.170"
+kcl-error = "=0.2.171"
+kcl-lib = { version = "=0.2.171", features = ["disable-println"] }
+kcl-test-server = "=0.2.171"
 kittycad = { version = "0.4.12", features = [
   "clap",
   "tabled",
   "requests",
   "retry",
 ] }
-kittycad-modeling-cmds = { version = "0.2.215", features = [
+kittycad-modeling-cmds = { version = "0.2.217", features = [
   "websocket",
   "tabled",
 ] }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -316,9 +316,7 @@ async fn run_test_item_with_config(config: &mut TestConfig, item: TestItem) {
         io,
         debug: false,
         override_host: None,
-        // TODO: Restore retries once the investigation into engine disconnects is complete.
-        // kcl_retry_config: Some(crate::context::RetryConfig::default()),
-        kcl_retry_config: None,
+        kcl_retry_config: Some(crate::context::RetryConfig::default()),
     };
 
     let _cwd_guard = CurrentDirGuard::change_to(item.current_directory.as_deref())


### PR DESCRIPTION
Test retries were re-enabled since it's difficult to pass CI. See #1731.