### PR TITLE
Revert retries to unmask engine disconnects

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -71,7 +71,6 @@ jobs:
           cargo llvm-cov nextest \
             --workspace --lcov --output-path=lcov.info \
             --partition=count:${{ matrix.partitionIndex }}/${{ matrix.partitionTotal }} \
-            --retries=5 \
             --profile=ci || true  # let TAB determine failure
           .github/workflows/lib/upload-results.sh
         env:

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -316,7 +316,9 @@ async fn run_test_item_with_config(config: &mut TestConfig, item: TestItem) {
         io,
         debug: false,
         override_host: None,
-        kcl_retry_config: Some(crate::context::RetryConfig::default()),
+        // TODO: Restore retries once the investigation into engine disconnects is complete.
+        // kcl_retry_config: Some(crate::context::RetryConfig::default()),
+        kcl_retry_config: None,
     };
 
     let _cwd_guard = CurrentDirGuard::change_to(item.current_directory.as_deref())


### PR DESCRIPTION
This partially reverts https://github.com/KittyCAD/cli/pull/1762 now that the related incident is resolved.