### PR TITLE
Remove unused test retry logic

### DIFF
--- a/src/cmd_alias.rs
+++ b/src/cmd_alias.rs
@@ -432,7 +432,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
 
             let cmd_alias = crate::cmd_alias::CmdAlias { subcmd: t.cmd };

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -614,7 +614,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
             if let Some(h) = &t.host {
                 ctx.override_host = Some(h.clone());

--- a/src/cmd_completion.rs
+++ b/src/cmd_completion.rs
@@ -139,7 +139,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
 
             cmd.run(&mut ctx).await.unwrap();

--- a/src/cmd_config.rs
+++ b/src/cmd_config.rs
@@ -265,7 +265,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
 
             let cmd_config = crate::cmd_config::CmdConfig { subcmd: t.cmd };
@@ -302,7 +301,6 @@ mod test {
             io,
             debug: false,
             override_host: None,
-            kcl_retry_config: None,
         };
 
         let mut cmd_config = crate::cmd_config::CmdConfig {

--- a/src/cmd_file.rs
+++ b/src/cmd_file.rs
@@ -868,7 +868,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
 
             let cmd_file = crate::cmd_file::CmdFile { subcmd: t.cmd };

--- a/src/cmd_generate.rs
+++ b/src/cmd_generate.rs
@@ -163,7 +163,6 @@ mod test {
             io,
             debug: false,
             override_host: None,
-            kcl_retry_config: None,
         };
 
         let cmd = crate::cmd_generate::CmdGenerateMarkdown { dir: "".to_string() };
@@ -193,7 +192,6 @@ mod test {
             io,
             debug: false,
             override_host: None,
-            kcl_retry_config: None,
         };
 
         let cmd = crate::cmd_generate::CmdGenerateMarkdown { dir: "".to_string() };

--- a/src/cmd_say.rs
+++ b/src/cmd_say.rs
@@ -116,7 +116,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
 
             let cmd_say = crate::cmd_say::CmdSay { input: t.cmd.input };

--- a/src/cmd_user.rs
+++ b/src/cmd_user.rs
@@ -86,7 +86,6 @@ mod test {
                 io,
                 debug: false,
                 override_host: None,
-                kcl_retry_config: None,
             };
 
             let cmd_user = crate::cmd_user::CmdUser { subcmd: t.cmd };

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,169 +36,37 @@ pub struct Context<'a> {
     pub debug: bool,
     // If set, override the host used when commands don't specify one.
     pub(crate) override_host: Option<String>,
-    /// Overrides retry behavior for KCL execution tests.
-    #[cfg(test)]
-    pub(crate) kcl_retry_config: Option<RetryConfig>,
 }
 
-/// Controls how retryable KCL execution failures are retried.
-#[derive(Debug, Clone)]
-pub(crate) struct RetryConfig {
-    retries: usize,
-    print_retries: bool,
-}
-
-impl RetryConfig {
-    /// Returns retry settings that make each KCL execution attempt run only
-    /// once.
-    fn no_retries() -> Self {
-        Self {
-            retries: 0,
-            print_retries: false,
-        }
-    }
-}
-
-#[cfg(test)]
-impl Default for RetryConfig {
-    /// Returns the retry settings used by tests that exercise retry handling.
-    fn default() -> Self {
-        Self {
-            retries: 2,
-            print_retries: true,
-        }
-    }
-}
-
-/// Result data captured from a single KCL program execution attempt.
+/// Result data captured from a KCL program execution.
 struct KclProgramRun {
     exec_ctx: kcl_lib::ExecutorContext,
     exec_state: kcl_lib::ExecState,
     session_data: Option<ModelingSessionData>,
 }
 
-/// Error type used to preserve KCL diagnostics across retry attempts.
-enum KclExecError {
-    /// A KCL error that should be formatted with filename and source context.
-    Err(Box<kcl_lib::KclError>),
-    /// A KCL execution error that already includes command outputs.
-    WithOutputs(Box<kcl_lib::KclErrorWithOutputs>),
-    /// Any non-KCL error from setup or issue checking.
-    Other(anyhow::Error),
-}
-
-impl KclExecError {
-    /// Converts the stored error into the diagnostic form expected by callers.
-    fn into_anyhow(self, filename: &str, code: &str) -> anyhow::Error {
-        match self {
-            Self::Err(err) => kcl_error_fmt::into_miette_for_parse(filename, code, *err),
-            Self::WithOutputs(err) => kcl_error_fmt::into_miette(*err, code),
-            Self::Other(err) => err,
-        }
-    }
-}
-
-impl std::fmt::Display for KclExecError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Err(err) => write!(formatter, "{err}"),
-            Self::WithOutputs(err) => write!(formatter, "{err}"),
-            Self::Other(err) => write!(formatter, "{err}"),
-        }
-    }
-}
-
-impl kcl_lib::IsRetryable for KclExecError {
-    fn is_retryable(&self) -> bool {
-        match self {
-            Self::Err(err) => kcl_lib::IsRetryable::is_retryable(err.as_ref()),
-            Self::WithOutputs(err) => kcl_lib::IsRetryable::is_retryable(err.as_ref()),
-            Self::Other(_) => false,
-        }
-    }
-}
-
-/// Runs an async operation until it succeeds, fails fatally, or exhausts
-/// retries.
-#[cfg(test)]
-async fn execute_with_retries<F, Fut, T, E>(config: &RetryConfig, mut execute: F) -> std::result::Result<T, E>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = std::result::Result<T, E>>,
-    E: kcl_lib::IsRetryable + std::fmt::Display,
-{
-    let mut retries_remaining = config.retries;
-    loop {
-        let exec_result = execute().await;
-
-        if should_retry_kcl_attempt(config, &mut retries_remaining, &exec_result) {
-            continue;
-        }
-
-        return exec_result;
-    }
-}
-
-/// Adjusts the retries remaining and returns whether a failed KCL attempt
-/// should be retried. This handles all the book-keeping of retrying.
-fn should_retry_kcl_attempt<T, E>(
-    config: &RetryConfig,
-    retries_remaining: &mut usize,
-    result: &std::result::Result<T, E>,
-) -> bool
-where
-    E: kcl_lib::IsRetryable + std::fmt::Display,
-{
-    if *retries_remaining > 0
-        && let Err(error) = result
-        && kcl_lib::IsRetryable::is_retryable(error)
-    {
-        if config.print_retries {
-            eprintln!("Execute got {error}; retrying...");
-        }
-        *retries_remaining -= 1;
-        true
-    } else {
-        false
-    }
-}
-
-/// Runs one KCL execution attempt and returns state needed for follow-up
-/// commands.
-async fn run_kcl_program_once_with_client(
+/// Runs a KCL program and returns state needed for follow-up commands.
+async fn run_kcl_program(
     client: &kittycad::Client,
     program: &kcl_lib::Program,
     settings: kcl_lib::ExecutorSettings,
-) -> std::result::Result<KclProgramRun, KclExecError> {
-    let ctx = kcl_lib::ExecutorContext::new(client, settings)
-        .await
-        .map_err(KclExecError::Other)?;
-    let mut exec_state = kcl_lib::ExecState::new(&ctx);
-    let session_data = ctx
+    code: &str,
+) -> Result<KclProgramRun> {
+    let exec_ctx = kcl_lib::ExecutorContext::new(client, settings).await?;
+    let mut exec_state = kcl_lib::ExecState::new(&exec_ctx);
+    let session_data = exec_ctx
         .run(program, &mut exec_state)
         .await
-        .map_err(|err| KclExecError::WithOutputs(Box::new(err)))?
+        .map_err(|err| kcl_error_fmt::into_miette(err, code))?
         .1;
     Ok(KclProgramRun {
-        exec_ctx: ctx,
+        exec_ctx,
         exec_state,
         session_data,
     })
 }
 
 impl<'a> Context<'a> {
-    /// Returns the retry settings to use for local KCL execution.
-    fn kcl_retry_config(&self) -> RetryConfig {
-        #[cfg(test)]
-        {
-            self.kcl_retry_config.clone().unwrap_or_else(RetryConfig::no_retries)
-        }
-        #[cfg(not(test))]
-        {
-            RetryConfig::no_retries()
-        }
-    }
-
     fn resolve_api_host_and_baseurl(&self, hostname: &str) -> Result<(String, String)> {
         let host = if !hostname.is_empty() {
             hostname.to_string()
@@ -272,8 +140,6 @@ impl<'a> Context<'a> {
             io,
             debug: false,
             override_host: None,
-            #[cfg(test)]
-            kcl_retry_config: None,
         }
     }
 
@@ -608,63 +474,42 @@ impl<'a> Context<'a> {
             .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
 
         let settings = cmd_kcl::with_heartbeats(settings);
-        let retry_config = self.kcl_retry_config();
-        let mut retries_remaining = retry_config.retries;
-        loop {
-            let result: std::result::Result<(OkWebSocketResponseData, Option<ModelingSessionData>), KclExecError> =
-                async {
-                    let run = run_kcl_program_once_with_client(&client, &program, settings.clone()).await?;
+        let run = run_kcl_program(&client, &program, settings, code).await?;
 
-                    kcl_error_fmt::check_exec_state_issues(
-                        &mut self.io.err_out,
-                        filename,
-                        code,
-                        &run.exec_state,
-                        issue_check,
-                    )
-                    .map_err(KclExecError::Other)?;
+        kcl_error_fmt::check_exec_state_issues(&mut self.io.err_out, filename, code, &run.exec_state, issue_check)?;
 
-                    let batch_context = kcl_lib::EngineBatchContext::new();
+        let batch_context = kcl_lib::EngineBatchContext::new();
 
-                    // Zoom on the object.
-                    run.exec_ctx
-                        .engine
-                        .send_modeling_cmd(
-                            &batch_context,
-                            uuid::Uuid::new_v4(),
-                            kcl_lib::SourceRange::default(),
-                            &ModelingCmd::from(
-                                mcmd::ZoomToFit::builder()
-                                    .animated(false)
-                                    .object_ids(Default::default())
-                                    .padding(0.1)
-                                    .build(),
-                            ),
-                        )
-                        .await
-                        .map_err(|err| KclExecError::Err(Box::new(err)))?;
+        // Zoom on the object.
+        run.exec_ctx
+            .engine
+            .send_modeling_cmd(
+                &batch_context,
+                uuid::Uuid::new_v4(),
+                kcl_lib::SourceRange::default(),
+                &ModelingCmd::from(
+                    mcmd::ZoomToFit::builder()
+                        .animated(false)
+                        .object_ids(Default::default())
+                        .padding(0.1)
+                        .build(),
+                ),
+            )
+            .await
+            .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
 
-                    let resp = run
-                        .exec_ctx
-                        .engine
-                        .send_modeling_cmd(
-                            &batch_context,
-                            uuid::Uuid::new_v4(),
-                            kcl_lib::SourceRange::default(),
-                            &cmd,
-                        )
-                        .await
-                        .map_err(|err| KclExecError::Err(Box::new(err)))?;
-                    Ok((resp, run.session_data))
-                }
-                .await;
-
-            if should_retry_kcl_attempt(&retry_config, &mut retries_remaining, &result) {
-                continue;
-            }
-
-            return result.map_err(|err| err.into_anyhow(filename, code));
-        }
+        let resp = run
+            .exec_ctx
+            .engine
+            .send_modeling_cmd(
+                &batch_context,
+                uuid::Uuid::new_v4(),
+                kcl_lib::SourceRange::default(),
+                &cmd,
+            )
+            .await
+            .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
+        Ok((resp, run.session_data))
     }
 
     pub(crate) async fn run_kcl_then_modeling_cmds(
@@ -688,49 +533,28 @@ impl<'a> Context<'a> {
             .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
 
         let settings = cmd_kcl::with_heartbeats(settings);
-        let retry_config = self.kcl_retry_config();
-        let mut retries_remaining = retry_config.retries;
-        loop {
-            let result: std::result::Result<(Vec<OkWebSocketResponseData>, Option<ModelingSessionData>), KclExecError> =
-                async {
-                    let run = run_kcl_program_once_with_client(&client, &program, settings.clone()).await?;
+        let run = run_kcl_program(&client, &program, settings, code).await?;
 
-                    kcl_error_fmt::check_exec_state_issues(
-                        &mut self.io.err_out,
-                        filename,
-                        code,
-                        &run.exec_state,
-                        issue_check,
-                    )
-                    .map_err(KclExecError::Other)?;
+        kcl_error_fmt::check_exec_state_issues(&mut self.io.err_out, filename, code, &run.exec_state, issue_check)?;
 
-                    let batch_context = kcl_lib::EngineBatchContext::new();
-                    let mut responses = Vec::with_capacity(cmds.len());
-                    for cmd in cmds.clone() {
-                        let resp = run
-                            .exec_ctx
-                            .engine
-                            .send_modeling_cmd(
-                                &batch_context,
-                                uuid::Uuid::new_v4(),
-                                kcl_lib::SourceRange::default(),
-                                &cmd,
-                            )
-                            .await
-                            .map_err(|err| KclExecError::Err(Box::new(err)))?;
-                        responses.push(resp);
-                    }
-
-                    Ok((responses, run.session_data))
-                }
-                .await;
-
-            if should_retry_kcl_attempt(&retry_config, &mut retries_remaining, &result) {
-                continue;
-            }
-
-            return result.map_err(|err| err.into_anyhow(filename, code));
+        let batch_context = kcl_lib::EngineBatchContext::new();
+        let mut responses = Vec::with_capacity(cmds.len());
+        for cmd in cmds {
+            let resp = run
+                .exec_ctx
+                .engine
+                .send_modeling_cmd(
+                    &batch_context,
+                    uuid::Uuid::new_v4(),
+                    kcl_lib::SourceRange::default(),
+                    &cmd,
+                )
+                .await
+                .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
+            responses.push(resp);
         }
+
+        Ok((responses, run.session_data))
     }
 
     /// Run the given KCL program, then after, run the given extra modeling commands.
@@ -774,54 +598,33 @@ impl<'a> Context<'a> {
             .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
 
         let settings = cmd_kcl::with_heartbeats(settings);
-        let retry_config = self.kcl_retry_config();
-        let mut retries_remaining = retry_config.retries;
-        loop {
-            let result: std::result::Result<(Vec<TakeSnapshot>, Option<ModelingSessionData>), KclExecError> = async {
-                let run = run_kcl_program_once_with_client(&client, &program, settings.clone()).await?;
+        let run = run_kcl_program(&client, &program, settings, code).await?;
 
-                kcl_error_fmt::check_exec_state_issues(
-                    &mut self.io.err_out,
-                    filename,
-                    code,
-                    &run.exec_state,
-                    issue_check,
+        kcl_error_fmt::check_exec_state_issues(&mut self.io.err_out, filename, code, &run.exec_state, issue_check)?;
+
+        let batch_context = kcl_lib::EngineBatchContext::new();
+        let mut snapshot_resps = Vec::new();
+        for snapshot_cmd in snapshot_cmds {
+            let resp = run
+                .exec_ctx
+                .engine
+                .send_modeling_cmd(
+                    &batch_context,
+                    uuid::Uuid::new_v4(),
+                    kcl_lib::SourceRange::default(),
+                    &snapshot_cmd,
                 )
-                .map_err(KclExecError::Other)?;
-
-                let batch_context = kcl_lib::EngineBatchContext::new();
-                let mut snapshot_resps = Vec::new();
-                for snapshot_cmd in snapshot_cmds.clone() {
-                    let resp = run
-                        .exec_ctx
-                        .engine
-                        .send_modeling_cmd(
-                            &batch_context,
-                            uuid::Uuid::new_v4(),
-                            kcl_lib::SourceRange::default(),
-                            &snapshot_cmd,
-                        )
-                        .await
-                        .map_err(|err| KclExecError::Err(Box::new(err)))?;
-                    if let OkWebSocketResponseData::Modeling {
-                        modeling_response:
-                            kittycad_modeling_cmds::ok_response::OkModelingCmdResponse::TakeSnapshot(snap),
-                    } = resp
-                    {
-                        snapshot_resps.push(snap);
-                    }
-                }
-
-                Ok((snapshot_resps, run.session_data))
+                .await
+                .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
+            if let OkWebSocketResponseData::Modeling {
+                modeling_response: kittycad_modeling_cmds::ok_response::OkModelingCmdResponse::TakeSnapshot(snap),
+            } = resp
+            {
+                snapshot_resps.push(snap);
             }
-            .await;
-
-            if should_retry_kcl_attempt(&retry_config, &mut retries_remaining, &result) {
-                continue;
-            }
-
-            return result.map_err(|err| err.into_anyhow(filename, code));
         }
+
+        Ok((snapshot_resps, run.session_data))
     }
 
     /// Runs KCL, checks execution issues, and exports the resulting files.
@@ -835,36 +638,16 @@ impl<'a> Context<'a> {
         output_format: kittycad_modeling_cmds::format::OutputFormat3d,
     ) -> Result<(Vec<RawFile>, Option<ModelingSessionData>)> {
         let client = self.api_client("")?;
-        let retry_config = self.kcl_retry_config();
-        let mut retries_remaining = retry_config.retries;
-        loop {
-            let result: std::result::Result<(Vec<RawFile>, Option<ModelingSessionData>), KclExecError> = async {
-                let run = run_kcl_program_once_with_client(&client, program, settings.clone()).await?;
+        let run = run_kcl_program(&client, program, settings, code).await?;
 
-                kcl_error_fmt::check_exec_state_issues(
-                    &mut self.io.err_out,
-                    filename,
-                    code,
-                    &run.exec_state,
-                    issue_check,
-                )
-                .map_err(KclExecError::Other)?;
+        kcl_error_fmt::check_exec_state_issues(&mut self.io.err_out, filename, code, &run.exec_state, issue_check)?;
 
-                let files = run
-                    .exec_ctx
-                    .export(output_format.clone())
-                    .await
-                    .map_err(|err| KclExecError::Err(Box::new(err)))?;
-                Ok((files, run.session_data))
-            }
-            .await;
-
-            if should_retry_kcl_attempt(&retry_config, &mut retries_remaining, &result) {
-                continue;
-            }
-
-            return result.map_err(|err| err.into_anyhow(filename, code));
-        }
+        let files = run
+            .exec_ctx
+            .export(output_format)
+            .await
+            .map_err(|err| kcl_error_fmt::into_miette_for_parse(filename, code, err))?;
+        Ok((files, run.session_data))
     }
 
     /// Create and poll a plain text-to-CAD job.
@@ -1677,30 +1460,6 @@ mod test {
 
     use super::*;
 
-    /// Test error used to verify retryable and fatal retry paths.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    enum RetryTestError {
-        /// Error variant that should be retried.
-        Retryable,
-        /// Error variant that should stop retrying.
-        Fatal,
-    }
-
-    impl std::fmt::Display for RetryTestError {
-        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::Retryable => write!(formatter, "retryable"),
-                Self::Fatal => write!(formatter, "fatal"),
-            }
-        }
-    }
-
-    impl kcl_lib::IsRetryable for RetryTestError {
-        fn is_retryable(&self) -> bool {
-            matches!(self, Self::Retryable)
-        }
-    }
-
     pub struct TestItem {
         name: String,
         zoo_pager_env: String,
@@ -1957,69 +1716,6 @@ mod test {
         assert!(md.contains("```text\nupdated notes\n```"));
     }
 
-    /// Verifies that retryable failures are retried until the operation
-    /// succeeds.
-    #[tokio::test]
-    async fn execute_with_retries_retries_retryable_errors() {
-        let retry_config = RetryConfig {
-            retries: 2,
-            print_retries: false,
-        };
-        let mut attempts = 0;
-
-        let result: std::result::Result<&str, RetryTestError> = execute_with_retries(&retry_config, || {
-            attempts += 1;
-            let attempt = attempts;
-            async move {
-                if attempt < 3 {
-                    Err(RetryTestError::Retryable)
-                } else {
-                    Ok("ok")
-                }
-            }
-        })
-        .await;
-
-        assert_eq!(result, Ok("ok"));
-        assert_eq!(attempts, 3);
-    }
-
-    /// Verifies that fatal failures are returned without retrying.
-    #[tokio::test]
-    async fn execute_with_retries_does_not_retry_fatal_errors() {
-        let retry_config = RetryConfig {
-            retries: 2,
-            print_retries: false,
-        };
-        let mut attempts = 0;
-
-        let result: std::result::Result<(), RetryTestError> = execute_with_retries(&retry_config, || {
-            attempts += 1;
-            async { Err(RetryTestError::Fatal) }
-        })
-        .await;
-
-        assert_eq!(result, Err(RetryTestError::Fatal));
-        assert_eq!(attempts, 1);
-    }
-
-    /// Verifies that retryable failures are not retried when retries are
-    /// disabled.
-    #[tokio::test]
-    async fn execute_with_retries_no_retries_does_not_retry_retryable_errors() {
-        let retry_config = RetryConfig::no_retries();
-        let mut attempts = 0;
-
-        let result: std::result::Result<(), RetryTestError> = execute_with_retries(&retry_config, || {
-            attempts += 1;
-            async { Err(RetryTestError::Retryable) }
-        })
-        .await;
-
-        assert_eq!(result, Err(RetryTestError::Retryable));
-        assert_eq!(attempts, 1);
-    }
-
     #[test]
     fn resolve_host_prefers_explicit_then_global() {
         let mut config = crate::config::new_blank_config().unwrap();
@@ -2030,7 +1726,6 @@ mod test {
             io,
             debug: false,
             override_host: None,
-            kcl_retry_config: None,
         };
 
         // No override: falls back to default host in config (which will be DEFAULT_HOST initially)
@@ -2064,7 +1759,6 @@ mod test {
             io,
             debug: false,
             override_host: None,
-            kcl_retry_config: None,
         };
 
         let (files, filepath) = ctx

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -316,9 +316,6 @@ async fn run_test_item_with_config(config: &mut TestConfig, item: TestItem) {
         io,
         debug: false,
         override_host: None,
-        // TODO: Restore retries once the investigation into engine disconnects is complete.
-        // kcl_retry_config: Some(crate::context::RetryConfig::default()),
-        kcl_retry_config: None,
     };
 
     let _cwd_guard = CurrentDirGuard::change_to(item.current_directory.as_deref())


### PR DESCRIPTION
This effectively reverts https://github.com/KittyCAD/cli/pull/1713, which we don't seem to need based on most tests reliably passing now.