### PR TITLE
Fix Nix Cargo vendoring and Rust 1.98 resolution

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -75,7 +76,9 @@ jobs:
       - name: Fix hash mismatches
         if: ${{ steps.nix_build.outcome == 'failure' }}
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           determinate-nixd fix hashes --auto-apply
 
@@ -85,6 +88,7 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "[dependabot skip] Automatically fix Nix hashes"
             git push origin "HEAD:${PR_HEAD_REF}"
+            gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-reviewer jessfraz
           else
             echo "No Nix hash changes were produced."
             exit 1

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -88,7 +88,9 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "[dependabot skip] Automatically fix Nix hashes"
             git push origin "HEAD:${PR_HEAD_REF}"
-            gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-reviewer jessfraz
+
+            gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-reviewer jessfraz || echo "Failed to add reviewer, but hash fixes were applied successfully"
+
           else
             echo "No Nix hash changes were produced."
             exit 1

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1784697913,
-        "narHash": "sha256-DK+AmC9SQ9hmOFNIMu1l05gJtsmKyYsfJnuFtt1TnAU=",
+        "lastModified": 1787540965,
+        "narHash": "sha256-48/4bbmK3W3Av3YPnrFb/tVQXPvBwU6kyM3Pb13VVD8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47759faaddf38fadaf172151ca9df8adae9c0b2e",
+        "rev": "ab450d47a3f906d19de1b332915bfc6e5b29c853",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,10 @@
     overlays = [
       (import rust-overlay)
       (self: super: {
-        rustToolchain =
-          (super.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
-            targets = ["wasm32-unknown-unknown"];
-            extensions = ["rustfmt" "llvm-tools-preview" "rust-src"];
-          };
+        rustToolchain = (super.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+          targets = ["wasm32-unknown-unknown"];
+          extensions = ["rustfmt" "llvm-tools-preview" "rust-src"];
+        };
 
         # stand-alone nightly formatter so we get the fancy unstable flags
         nightlyRustfmt = super.rust-bin.selectLatestNightlyWith (toolchain:
@@ -78,13 +77,7 @@
         version = cargoToml.package.version;
         src = ./.;
 
-        cargoLock = {
-          lockFile = ./Cargo.lock;
-          outputHashes = {
-            "kittycad-0.4.14" = "sha256-fkA4rl6MTZgzFtmDQRvkAKARoOhjmEcZMyRw+cNmYxA=";
-            "openapitor-0.0.9" = "sha256-XdcR9KzUY1IIgJ5YSlLeV1XVValS22WMxUbz0qUKX14=";
-          };
-        };
+        cargoHash = "sha256-wnE6S9BderCCPE6HKizvvnUwQknswuy6+G7XHXcZ6/o=";
 
         doCheck = false;
         nativeBuildInputs = [pkgs.pkg-config];


### PR DESCRIPTION
## Summary

- replace per-Git-dependency output hashes with one Cargo vendor hash
- make Cargo.lock drift produce the standard fixed-output hash mismatch handled by the existing nix-fix-hashes workflow
- update rust-overlay so the declared Rust 1.98 toolchain resolves
- keep the existing Zoo package interface unchanged

## Validation

- alejandra --check flake.nix
- git diff --check
- nix flake check --no-build --all-systems
- Zoo vendoring completed locally; final compilation was stopped after exceeding five minutes per repository instructions
- GitHub nix-flake-check passed; Linux and macOS Nix builds are running