### PR TITLE
Surface API response bodies on errors

### DIFF
--- a/src/cmd_api.rs
+++ b/src/cmd_api.rs
@@ -189,7 +189,12 @@ impl crate::cmd::Command for CmdApi {
             }
 
             if !status.is_success() {
-                return Err(anyhow!("{} {}", status, status.canonical_reason().unwrap_or("")));
+                let body = resp.text().await?;
+                return Err(if body.is_empty() {
+                    anyhow!("{status}")
+                } else {
+                    anyhow!("{status}: {body}")
+                });
             }
 
             if self.paginate {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -520,7 +520,7 @@ cli_tests! {
             svec!["zoo", "api", "foo/bar"],
         )
         .setup(setup_authenticated)
-        .stderr_contains("404 Not Found Not Found")
+        .stderr_contains("404 Not Found:")
         .exit_code(1)
     }
 


### PR DESCRIPTION
## Summary

- read the response body before returning a `zoo api` HTTP error
- include a non-empty server response in the error message
- format the HTTP status once instead of repeating its reason phrase

## Tests

- `cargo fmt --check`
- focused test target compiled locally; execution requires `ZOO_TEST_TOKEN` and will run in CI

Closes #1754
