### PR TITLE
Reject unsupported KCL format output

### DIFF
--- a/src/cmd_kcl.rs
+++ b/src/cmd_kcl.rs
@@ -285,6 +285,8 @@ impl crate::cmd::Command for CmdKclFormat {
             if format == &FormatOutput::Json {
                 // Print the formatted file to stdout as json.
                 writeln!(ctx.io.out, "{}", serde_json::to_string_pretty(&program)?)?;
+            } else {
+                anyhow::bail!("the `{format}` output format is not supported for `zoo kcl format`");
             }
         } else {
             // Print the formatted file to stdout.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -682,6 +682,15 @@ cli_tests! {
         .stdout_contains(r#""mass": 0.000858"#)
     }
 
+    format_kcl_rejects_unsupported_output(_ctx) => {
+        TestItem::new(
+            "format kcl rejects unsupported output",
+            svec!["zoo", "kcl", "format", "tests/gear.kcl", "--format", "yaml"],
+        )
+        .stderr_contains("the `yaml` output format is not supported for `zoo kcl format`")
+        .exit_code(1)
+    }
+
     snapshot_a_kcl_file_as_png(_ctx) => {
         TestItem::new(
             "snapshot a kcl file as png",


### PR DESCRIPTION
## Summary

- reject YAML and table output explicitly for `zoo kcl format`
- avoid successful commands that silently produce empty stdout
- keep JSON and default formatted-source output unchanged

## Tests

- `cargo fmt --check`
- `ZOO_TEST_TOKEN=dummy cargo test format_kcl_rejects_unsupported_output --no-fail-fast`

Closes #1751
