### PR TITLE
Use a simple fixture for the project.toml analysis test

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -886,7 +886,7 @@ cli_tests! {
                 "zoo",
                 "kcl",
                 "analyze",
-                "tests/with-settings/gear.kcl",
+                "tests/with-settings/cylinder.kcl",
                 "--format=json",
                 "--volume-output-unit",
                 "cm3",

--- a/tests/with-settings/cylinder.kcl
+++ b/tests/with-settings/cylinder.kcl
@@ -1,0 +1,5 @@
+@settings(defaultLengthUnit = mm)
+
+cylinder = startSketchOn(XY)
+  |> circle(center = [0, 0], radius = 5)
+  |> extrude(length = 10)


### PR DESCRIPTION
## Summary

- add a five-line cylinder fixture beside the existing project settings
- use it only for the project.toml analysis test
- keep the existing gear fixture for snapshot and mass coverage

Fixes #1766.

## Testing

- `cargo fmt --check`
- `cargo test analyze_a_kcl_file_and_use_project_toml --no-run`
- `zoo kcl format tests/with-settings/cylinder.kcl`

The authenticated engine execution was not run locally because `ZOO_TEST_TOKEN` is not available.