### PR TITLE
Upgrade rust toolchain to 1.98.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.98"
+channel = "1.98.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/