### PR TITLE
Enable Clap parsing for KCL measurement units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -789,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2641,7 +2641,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2950,13 +2950,13 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.231"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba195dedccad5ba676cfbdc424da3732c6fd8c199d85f9f730da7203c4b3fce"
+version = "0.2.228"
+source = "git+https://github.com/KittyCAD/modeling-api?rev=52ecdb59580435964776ad458e2036b73a4ef7d7#52ecdb59580435964776ad458e2036b73a4ef7d7"
 dependencies = [
  "anyhow",
  "bon",
  "chrono",
+ "clap",
  "data-encoding",
  "enum-iterator",
  "enum-iterator-derive",
@@ -2983,24 +2983,22 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
+source = "git+https://github.com/KittyCAD/modeling-api?rev=52ecdb59580435964776ad458e2036b73a4ef7d7#52ecdb59580435964776ad458e2036b73a4ef7d7"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
+source = "git+https://github.com/KittyCAD/modeling-api?rev=52ecdb59580435964776ad458e2036b73a4ef7d7#52ecdb59580435964776ad458e2036b73a4ef7d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3466,7 +3464,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4208,7 +4206,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4812,7 +4810,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4825,7 +4823,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5709,7 +5707,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5718,7 +5716,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5737,7 +5735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6709,7 +6707,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -789,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2641,7 +2641,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2950,8 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.228"
-source = "git+https://github.com/KittyCAD/modeling-api?rev=52ecdb59580435964776ad458e2036b73a4ef7d7#52ecdb59580435964776ad458e2036b73a4ef7d7"
+version = "0.2.231"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba195dedccad5ba676cfbdc424da3732c6fd8c199d85f9f730da7203c4b3fce"
 dependencies = [
  "anyhow",
  "bon",
@@ -2983,22 +2984,24 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.13"
-source = "git+https://github.com/KittyCAD/modeling-api?rev=52ecdb59580435964776ad458e2036b73a4ef7d7#52ecdb59580435964776ad458e2036b73a4ef7d7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
 version = "0.1.14"
-source = "git+https://github.com/KittyCAD/modeling-api?rev=52ecdb59580435964776ad458e2036b73a4ef7d7#52ecdb59580435964776ad458e2036b73a4ef7d7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3464,7 +3467,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4206,7 +4209,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4810,7 +4813,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4823,7 +4826,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5707,7 +5710,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5716,7 +5719,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5735,7 +5738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6707,7 +6710,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ incremental = true
 debug = 0
 
 # Use the same modeling-command types in the CLI and its KCL dependencies.
-# modeling-api#1369 plus the companion fix preserving existing unit spellings.
+# v0.2.229 omits the unit spellings and volume Clap support fixed by modeling-api#1370.
+# Remove this patch once a crates.io release includes those fixes.
 [patch.crates-io]
 kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api", rev = "52ecdb59580435964776ad458e2036b73a4ef7d7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,8 @@ kittycad = { version = "0.5", features = [
   "requests",
   "retry",
 ] }
-kittycad-modeling-cmds = { version = "0.2.224", features = [
+kittycad-modeling-cmds = { version = "0.2.228", features = [
+  "clap",
   "exec-kcl",
   "websocket",
   "tabled",
@@ -128,3 +129,8 @@ debug = 0
 incremental = true
 # Set this to 1 or 2 to get more useful backtraces in debugger.
 debug = 0
+
+# Use the same modeling-command types in the CLI and its KCL dependencies.
+# modeling-api#1369 plus the companion fix preserving existing unit spellings.
+[patch.crates-io]
+kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api", rev = "52ecdb59580435964776ad458e2036b73a4ef7d7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ kittycad = { version = "0.5", features = [
   "requests",
   "retry",
 ] }
-kittycad-modeling-cmds = { version = "0.2.228", features = [
+kittycad-modeling-cmds = { version = "0.2.230", features = [
   "clap",
   "exec-kcl",
   "websocket",
@@ -129,9 +129,3 @@ debug = 0
 incremental = true
 # Set this to 1 or 2 to get more useful backtraces in debugger.
 debug = 0
-
-# Use the same modeling-command types in the CLI and its KCL dependencies.
-# v0.2.229 omits the unit spellings and volume Clap support fixed by modeling-api#1370.
-# Remove this patch once a crates.io release includes those fixes.
-[patch.crates-io]
-kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api", rev = "52ecdb59580435964776ad458e2036b73a4ef7d7" }

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
         version = cargoToml.package.version;
         src = ./.;
 
-        cargoHash = "sha256-S9FTL+zb0NyeAwot50BBTAKA7Gb3fTSQpFKnPt60e94=";
+        cargoHash = "sha256-5lGALJ4rkV+7MwKSw50ASoUnw6sn2qPvT2QdM7rAn2E=";
 
         doCheck = false;
         nativeBuildInputs = [pkgs.pkg-config];

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
         version = cargoToml.package.version;
         src = ./.;
 
-        cargoHash = "sha256-5lGALJ4rkV+7MwKSw50ASoUnw6sn2qPvT2QdM7rAn2E=";
+        cargoHash = "sha256-S9FTL+zb0NyeAwot50BBTAKA7Gb3fTSQpFKnPt60e94=";
 
         doCheck = false;
         nativeBuildInputs = [pkgs.pkg-config];

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
         version = cargoToml.package.version;
         src = ./.;
 
-        cargoHash = "sha256-5lGALJ4rkV+7MwKSw50ASoUnw6sn2qPvT2QdM7rAn2E=";
+        cargoHash = "sha256-snbbV1v950AUGSfr6UR/nIsk6NYMYpqzbYUaGVtOo2k=";
 
         doCheck = false;
         nativeBuildInputs = [pkgs.pkg-config];

--- a/src/cmd_kcl.rs
+++ b/src/cmd_kcl.rs
@@ -20,21 +20,6 @@ mod camera_angles;
 /// Send a heartbeat every N seconds.
 pub const HEARTBEATS: u64 = 3;
 
-fn modeling_volume_unit(unit: &kt::UnitVolume) -> kcmc::units::UnitVolume {
-    match unit {
-        kt::UnitVolume::Mm3 => kcmc::units::UnitVolume::CubicMillimeters,
-        kt::UnitVolume::Cm3 => kcmc::units::UnitVolume::CubicCentimeters,
-        kt::UnitVolume::Ft3 => kcmc::units::UnitVolume::CubicFeet,
-        kt::UnitVolume::In3 => kcmc::units::UnitVolume::CubicInches,
-        kt::UnitVolume::M3 => kcmc::units::UnitVolume::CubicMeters,
-        kt::UnitVolume::Yd3 => kcmc::units::UnitVolume::CubicYards,
-        kt::UnitVolume::Usfloz => kcmc::units::UnitVolume::FluidOunces,
-        kt::UnitVolume::Usgal => kcmc::units::UnitVolume::Gallons,
-        kt::UnitVolume::L => kcmc::units::UnitVolume::Liters,
-        kt::UnitVolume::Ml => kcmc::units::UnitVolume::Milliliters,
-    }
-}
-
 pub(crate) fn with_heartbeats(mut settings: kcl_lib::ExecutorSettings) -> kcl_lib::ExecutorSettings {
     if settings.heartbeats.is_none() {
         settings.heartbeats = Some(HEARTBEATS);
@@ -1007,7 +992,7 @@ pub struct CmdKclAnalyze {
 
     /// What units do you want volumes shown in?
     #[clap(long = "volume-output-unit", value_enum, default_value = "m3")]
-    pub volume_output_unit: kt::UnitVolume,
+    pub volume_output_unit: kcmc::units::UnitVolume,
 
     /// What units do you want masses shown in?
     #[clap(long = "mass-output-unit", value_enum, default_value = "kg")]
@@ -1052,11 +1037,7 @@ impl crate::cmd::Command for CmdKclAnalyze {
                 &filepath.display().to_string(),
                 &code,
                 vec![
-                    kcmc::ModelingCmd::Volume(
-                        kcmc::Volume::builder()
-                            .output_unit(modeling_volume_unit(&self.volume_output_unit))
-                            .build(),
-                    ),
+                    kcmc::ModelingCmd::Volume(kcmc::Volume::builder().output_unit(self.volume_output_unit).build()),
                     kcmc::ModelingCmd::Mass(
                         kcmc::Mass::builder()
                             .material_density(self.material_density.into())
@@ -1179,7 +1160,7 @@ pub struct CmdKclVolume {
 
     /// Output unit.
     #[clap(long = "output-unit", short = 'u', value_enum)]
-    pub output_unit: kt::UnitVolume,
+    pub output_unit: kcmc::units::UnitVolume,
 
     /// If true, print a link to this request's tracing data.
     #[clap(long, default_value = "false")]
@@ -1238,7 +1219,7 @@ impl crate::cmd::Command for CmdKclVolume {
                 kittycad_modeling_cmds::ModelingCmd::Volume(
                     kittycad_modeling_cmds::Volume::builder()
                         .entity_ids(vec![]) // get whole model
-                        .output_unit(modeling_volume_unit(&self.output_unit))
+                        .output_unit(self.output_unit)
                         .build(),
                 ),
                 executor_settings,
@@ -2029,7 +2010,7 @@ mod tests {
         let kcl = CmdKclVolume::try_parse_from(["volume", "part.kcl", "--output-unit", "mm3"]).unwrap();
 
         assert_eq!(file.output_unit, kt::UnitVolume::Mm3);
-        assert_eq!(kcl.output_unit, kt::UnitVolume::Mm3);
+        assert_eq!(kcl.output_unit, kcmc::units::UnitVolume::CubicMillimeters);
     }
 
     #[test]
@@ -2045,11 +2026,38 @@ mod tests {
     }
 
     #[test]
-    fn api_volume_units_map_to_the_same_modeling_spelling() {
+    fn file_and_kcl_volume_accept_the_same_unit_spellings() {
         for unit in kt::UnitVolume::value_variants() {
             let cli_spelling = unit.to_possible_value().unwrap().get_name().to_owned();
 
-            assert_eq!(modeling_volume_unit(unit).to_string(), cli_spelling);
+            let volume = CmdKclVolume::try_parse_from(["volume", "part.kcl", "--output-unit", &cli_spelling]).unwrap();
+            let analyze =
+                CmdKclAnalyze::try_parse_from(["analyze", "part.kcl", "--volume-output-unit", &cli_spelling]).unwrap();
+
+            assert_eq!(volume.output_unit.to_string(), cli_spelling);
+            assert_eq!(analyze.volume_output_unit, volume.output_unit);
+        }
+    }
+
+    #[test]
+    fn kcl_analyze_accepts_default_units_and_density_aliases() {
+        let analyze = CmdKclAnalyze::try_parse_from(["analyze", "part.kcl"]).unwrap();
+        assert_eq!(analyze.volume_output_unit, kcmc::units::UnitVolume::CubicMeters);
+        assert_eq!(analyze.mass_output_unit, kcmc::units::UnitMass::Kilograms);
+        assert_eq!(
+            analyze.density_output_unit,
+            kcmc::units::UnitDensity::KilogramsPerCubicMeter
+        );
+        assert_eq!(analyze.surface_area_output_unit, kcmc::units::UnitArea::SquareMeters);
+        assert_eq!(analyze.center_of_mass_output_unit, kcmc::units::UnitLength::Meters);
+
+        for spelling in ["lbft3", "lb:ft3", "lb-ft3", "kgm3", "kg:m3", "kg-m3"] {
+            let analyze =
+                CmdKclAnalyze::try_parse_from(["analyze", "part.kcl", "--material-density-unit", spelling]).unwrap();
+            assert_eq!(
+                analyze.material_density_unit,
+                <kcmc::units::UnitDensity as std::str::FromStr>::from_str(spelling).unwrap()
+            );
         }
     }
 

--- a/src/cmd_kcl.rs
+++ b/src/cmd_kcl.rs
@@ -2001,8 +2001,6 @@ mod tests {
 
     use super::*;
 
-    const POSSIBLE_VOLUME_UNITS: &str = "[possible values: mm3, cm3, ft3, in3, m3, yd3, usfloz, usgal, l, ml]";
-
     #[test]
     fn file_and_kcl_volume_accept_mm3() {
         let file =
@@ -2011,18 +2009,6 @@ mod tests {
 
         assert_eq!(file.output_unit, kt::UnitVolume::Mm3);
         assert_eq!(kcl.output_unit, kcmc::units::UnitVolume::CubicMillimeters);
-    }
-
-    #[test]
-    fn kcl_volume_invalid_units_list_possible_values() {
-        let volume_error = CmdKclVolume::try_parse_from(["volume", "part.kcl", "--output-unit", "bogus"]).unwrap_err();
-        let analyze_error =
-            CmdKclAnalyze::try_parse_from(["analyze", "part.kcl", "--volume-output-unit", "bogus"]).unwrap_err();
-
-        for error in [volume_error, analyze_error] {
-            assert_eq!(error.kind(), ErrorKind::InvalidValue);
-            assert!(error.to_string().contains(POSSIBLE_VOLUME_UNITS));
-        }
     }
 
     #[test]
@@ -2039,8 +2025,71 @@ mod tests {
         }
     }
 
+    // Exercise the actual command parsers: enabling ValueEnum must preserve the
+    // public abbreviations and list them when a user supplies an invalid unit.
+    fn assert_kcl_unit_choices(command: &str, flag: &str, units: &[&str]) {
+        let mut args = vec!["kcl", command, "part.kcl"];
+        let required = match command {
+            "mass" => vec![
+                ("--material-density", "1"),
+                ("--material-density-unit", "kg:m3"),
+                ("--output-unit", "kg"),
+            ],
+            "density" => vec![
+                ("--material-mass", "1"),
+                ("--material-mass-unit", "kg"),
+                ("--output-unit", "kg:m3"),
+            ],
+            _ => vec![],
+        };
+        for (required_flag, value) in required {
+            if required_flag != flag {
+                args.extend([required_flag, value]);
+            }
+        }
+        args.push(flag);
+
+        for unit in units {
+            let parsed = CmdKcl::try_parse_from(args.iter().copied().chain([*unit]));
+            assert!(parsed.is_ok(), "{command} {flag} {unit}: {parsed:?}");
+        }
+
+        let error = CmdKcl::try_parse_from(args.iter().copied().chain(["bogus"])).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidValue, "{command} {flag}: {error}");
+        let choices = format!("[possible values: {}]", units.join(", "));
+        assert!(error.to_string().contains(&choices), "{command} {flag}: {error}");
+    }
+
     #[test]
-    fn kcl_analyze_accepts_default_units_and_density_aliases() {
+    fn all_kcl_measurement_flags_preserve_unit_choices() {
+        let length = ["cm", "ft", "in", "m", "mm", "yd"];
+        let area = ["cm2", "dm2", "ft2", "in2", "km2", "m2", "mm2", "yd2"];
+        let mass = ["g", "kg", "lb"];
+        let density = ["lb:ft3", "kg:m3"];
+        let volume = ["mm3", "cm3", "ft3", "in3", "m3", "yd3", "usfloz", "usgal", "l", "ml"];
+        let cases: &[(&str, &str, &[&str])] = &[
+            ("volume", "--output-unit", &volume),
+            ("mass", "--output-unit", &mass),
+            ("mass", "--material-density-unit", &density),
+            ("density", "--output-unit", &density),
+            ("density", "--material-mass-unit", &mass),
+            ("surface-area", "--output-unit", &area),
+            ("center-of-mass", "--output-unit", &length),
+            ("bounding-box", "--output-unit", &length),
+            ("analyze", "--volume-output-unit", &volume),
+            ("analyze", "--mass-output-unit", &mass),
+            ("analyze", "--density-output-unit", &density),
+            ("analyze", "--material-density-unit", &density),
+            ("analyze", "--surface-area-output-unit", &area),
+            ("analyze", "--center-of-mass-output-unit", &length),
+        ];
+        for (command, flag, units) in cases {
+            assert_kcl_unit_choices(command, flag, units);
+        }
+    }
+
+    #[test]
+    fn kcl_measurements_preserve_defaults_and_density_aliases() {
         let analyze = CmdKclAnalyze::try_parse_from(["analyze", "part.kcl"]).unwrap();
         assert_eq!(analyze.volume_output_unit, kcmc::units::UnitVolume::CubicMeters);
         assert_eq!(analyze.mass_output_unit, kcmc::units::UnitMass::Kilograms);
@@ -2052,12 +2101,42 @@ mod tests {
         assert_eq!(analyze.center_of_mass_output_unit, kcmc::units::UnitLength::Meters);
 
         for spelling in ["lbft3", "lb:ft3", "lb-ft3", "kgm3", "kg:m3", "kg-m3"] {
-            let analyze =
-                CmdKclAnalyze::try_parse_from(["analyze", "part.kcl", "--material-density-unit", spelling]).unwrap();
-            assert_eq!(
-                analyze.material_density_unit,
-                <kcmc::units::UnitDensity as std::str::FromStr>::from_str(spelling).unwrap()
-            );
+            let analyze = CmdKclAnalyze::try_parse_from([
+                "analyze",
+                "part.kcl",
+                "--material-density-unit",
+                spelling,
+                "--density-output-unit",
+                spelling,
+            ])
+            .unwrap();
+            let mass = CmdKclMass::try_parse_from([
+                "mass",
+                "part.kcl",
+                "--material-density",
+                "1",
+                "--material-density-unit",
+                spelling,
+                "--output-unit",
+                "kg",
+            ])
+            .unwrap();
+            let density = CmdKclDensity::try_parse_from([
+                "density",
+                "part.kcl",
+                "--material-mass",
+                "1",
+                "--material-mass-unit",
+                "kg",
+                "--output-unit",
+                spelling,
+            ])
+            .unwrap();
+            let expected = <kcmc::units::UnitDensity as std::str::FromStr>::from_str(spelling).unwrap();
+            assert_eq!(analyze.material_density_unit, expected);
+            assert_eq!(analyze.density_output_unit, expected);
+            assert_eq!(mass.material_density_unit, expected);
+            assert_eq!(density.output_unit, expected);
         }
     }
 

--- a/src/cmd_kcl.rs
+++ b/src/cmd_kcl.rs
@@ -20,6 +20,21 @@ mod camera_angles;
 /// Send a heartbeat every N seconds.
 pub const HEARTBEATS: u64 = 3;
 
+fn modeling_volume_unit(unit: &kt::UnitVolume) -> kcmc::units::UnitVolume {
+    match unit {
+        kt::UnitVolume::Mm3 => kcmc::units::UnitVolume::CubicMillimeters,
+        kt::UnitVolume::Cm3 => kcmc::units::UnitVolume::CubicCentimeters,
+        kt::UnitVolume::Ft3 => kcmc::units::UnitVolume::CubicFeet,
+        kt::UnitVolume::In3 => kcmc::units::UnitVolume::CubicInches,
+        kt::UnitVolume::M3 => kcmc::units::UnitVolume::CubicMeters,
+        kt::UnitVolume::Yd3 => kcmc::units::UnitVolume::CubicYards,
+        kt::UnitVolume::Usfloz => kcmc::units::UnitVolume::FluidOunces,
+        kt::UnitVolume::Usgal => kcmc::units::UnitVolume::Gallons,
+        kt::UnitVolume::L => kcmc::units::UnitVolume::Liters,
+        kt::UnitVolume::Ml => kcmc::units::UnitVolume::Milliliters,
+    }
+}
+
 pub(crate) fn with_heartbeats(mut settings: kcl_lib::ExecutorSettings) -> kcl_lib::ExecutorSettings {
     if settings.heartbeats.is_none() {
         settings.heartbeats = Some(HEARTBEATS);
@@ -992,7 +1007,7 @@ pub struct CmdKclAnalyze {
 
     /// What units do you want volumes shown in?
     #[clap(long = "volume-output-unit", value_enum, default_value = "m3")]
-    pub volume_output_unit: kcmc::units::UnitVolume,
+    pub volume_output_unit: kt::UnitVolume,
 
     /// What units do you want masses shown in?
     #[clap(long = "mass-output-unit", value_enum, default_value = "kg")]
@@ -1037,7 +1052,11 @@ impl crate::cmd::Command for CmdKclAnalyze {
                 &filepath.display().to_string(),
                 &code,
                 vec![
-                    kcmc::ModelingCmd::Volume(kcmc::Volume::builder().output_unit(self.volume_output_unit).build()),
+                    kcmc::ModelingCmd::Volume(
+                        kcmc::Volume::builder()
+                            .output_unit(modeling_volume_unit(&self.volume_output_unit))
+                            .build(),
+                    ),
                     kcmc::ModelingCmd::Mass(
                         kcmc::Mass::builder()
                             .material_density(self.material_density.into())
@@ -1160,7 +1179,7 @@ pub struct CmdKclVolume {
 
     /// Output unit.
     #[clap(long = "output-unit", short = 'u', value_enum)]
-    pub output_unit: kcmc::units::UnitVolume,
+    pub output_unit: kt::UnitVolume,
 
     /// If true, print a link to this request's tracing data.
     #[clap(long, default_value = "false")]
@@ -1219,7 +1238,7 @@ impl crate::cmd::Command for CmdKclVolume {
                 kittycad_modeling_cmds::ModelingCmd::Volume(
                     kittycad_modeling_cmds::Volume::builder()
                         .entity_ids(vec![]) // get whole model
-                        .output_unit(self.output_unit)
+                        .output_unit(modeling_volume_unit(&self.output_unit))
                         .build(),
                 ),
                 executor_settings,
@@ -1997,7 +2016,42 @@ fn combine_quadrants(
 
 #[cfg(test)]
 mod tests {
+    use clap::{ValueEnum, error::ErrorKind};
+
     use super::*;
+
+    const POSSIBLE_VOLUME_UNITS: &str = "[possible values: mm3, cm3, ft3, in3, m3, yd3, usfloz, usgal, l, ml]";
+
+    #[test]
+    fn file_and_kcl_volume_accept_mm3() {
+        let file =
+            crate::cmd_file::CmdFileVolume::try_parse_from(["volume", "part.step", "--output-unit", "mm3"]).unwrap();
+        let kcl = CmdKclVolume::try_parse_from(["volume", "part.kcl", "--output-unit", "mm3"]).unwrap();
+
+        assert_eq!(file.output_unit, kt::UnitVolume::Mm3);
+        assert_eq!(kcl.output_unit, kt::UnitVolume::Mm3);
+    }
+
+    #[test]
+    fn kcl_volume_invalid_units_list_possible_values() {
+        let volume_error = CmdKclVolume::try_parse_from(["volume", "part.kcl", "--output-unit", "bogus"]).unwrap_err();
+        let analyze_error =
+            CmdKclAnalyze::try_parse_from(["analyze", "part.kcl", "--volume-output-unit", "bogus"]).unwrap_err();
+
+        for error in [volume_error, analyze_error] {
+            assert_eq!(error.kind(), ErrorKind::InvalidValue);
+            assert!(error.to_string().contains(POSSIBLE_VOLUME_UNITS));
+        }
+    }
+
+    #[test]
+    fn api_volume_units_map_to_the_same_modeling_spelling() {
+        for unit in kt::UnitVolume::value_variants() {
+            let cli_spelling = unit.to_possible_value().unwrap().get_name().to_owned();
+
+            assert_eq!(modeling_volume_unit(unit).to_string(), cli_spelling);
+        }
+    }
 
     #[test]
     fn with_heartbeats_adds_cli_default() {


### PR DESCRIPTION
Enable the released modeling-command Clap support so KCL measurement flags accept existing unit spellings and list valid choices for invalid input. Require 0.2.230 and preserve regression coverage for unit choices, defaults, and density aliases.

Fixes #1744. Formatting, lockfile, and Nix-hash checks pass; builds and tests run in CI.