### PR TITLE
Log status messages to stderr if using JSON/YAML output

### DIFF
--- a/src/cmd_file.rs
+++ b/src/cmd_file.rs
@@ -99,6 +99,7 @@ pub struct CmdFileConvert {
 #[async_trait::async_trait(?Send)]
 impl crate::cmd::Command for CmdFileConvert {
     async fn run(&self, ctx: &mut crate::context::Context) -> Result<()> {
+        let format = ctx.format(&self.format)?;
         // Make sure the output dir is a directory.
         if !self.output_dir.is_dir() {
             anyhow::bail!(
@@ -137,11 +138,9 @@ impl crate::cmd::Command for CmdFileConvert {
                     } else {
                         std::fs::write(&path, data)?;
                     }
-                    writeln!(
-                        ctx.io.out,
-                        "wrote file `{}` to {}",
-                        filename,
-                        path.to_str().unwrap_or("")
+                    ctx.io.write_status(
+                        &format,
+                        format_args!("wrote file `{}` to {}", filename, path.to_str().unwrap_or("")),
                     )?;
                 }
             } else {
@@ -156,7 +155,6 @@ impl crate::cmd::Command for CmdFileConvert {
         file_conversion.outputs = None;
 
         // Print the output of the conversion.
-        let format = ctx.format(&self.format)?;
         ctx.io.write_output(&format, &file_conversion)?;
 
         Ok(())

--- a/src/cmd_project.rs
+++ b/src/cmd_project.rs
@@ -359,6 +359,7 @@ pub struct CmdProjectPublish {
 #[async_trait::async_trait(?Send)]
 impl crate::cmd::Command for CmdProjectPublish {
     async fn run(&self, ctx: &mut crate::context::Context) -> Result<()> {
+        let format = ctx.format(&self.format)?;
         let environment = ctx.project_cloud_environment_name("")?;
         let target = resolve_project_target(&self.input, &environment)?;
         let project_id = target.id();
@@ -369,14 +370,15 @@ impl crate::cmd::Command for CmdProjectPublish {
         if let ProjectTarget::Local { local, .. } = target {
             crate::project::persist_cloud_project_id(&local.project_toml, &environment, project.id)?;
         }
-        writeln!(
-            ctx.io.out,
-            "{} Submitted Zoo cloud project {} for publication review",
-            ctx.io.color_scheme().success_icon(),
-            project.id
+        ctx.io.write_status(
+            &format,
+            format_args!(
+                "{} Submitted Zoo cloud project {} for publication review",
+                ctx.io.color_scheme().success_icon(),
+                project.id
+            ),
         )?;
 
-        let format = ctx.format(&self.format)?;
         write_project_output(ctx, &format, &project)?;
         Ok(())
     }
@@ -417,6 +419,7 @@ pub struct CmdProjectUpload {
 #[async_trait::async_trait(?Send)]
 impl crate::cmd::Command for CmdProjectUpload {
     async fn run(&self, ctx: &mut crate::context::Context) -> Result<()> {
+        let format = ctx.format(&self.format)?;
         let local = crate::project::resolve_local_project(&self.input)?;
         let environment = ctx.project_cloud_environment_name("")?;
         let existing_id = match self.id {
@@ -443,16 +446,17 @@ impl crate::cmd::Command for CmdProjectUpload {
         };
 
         crate::project::persist_cloud_project_id(&local.project_toml, &environment, project.id)?;
-        writeln!(
-            ctx.io.out,
-            "{} {} Zoo cloud project id {} in {}",
-            ctx.io.color_scheme().success_icon(),
-            if existing_id.is_some() { "Updated" } else { "Stored" },
-            project.id,
-            local.project_toml.display()
+        ctx.io.write_status(
+            &format,
+            format_args!(
+                "{} {} Zoo cloud project id {} in {}",
+                ctx.io.color_scheme().success_icon(),
+                if existing_id.is_some() { "Updated" } else { "Stored" },
+                project.id,
+                local.project_toml.display()
+            ),
         )?;
 
-        let format = ctx.format(&self.format)?;
         write_project_output(ctx, &format, &project)?;
         Ok(())
     }

--- a/src/iostreams.rs
+++ b/src/iostreams.rs
@@ -226,6 +226,22 @@ impl IoStreams {
         crate::colors::ColorScheme::new(self.color_enabled(), self.color_support_256(), self.has_true_color())
     }
 
+    /// Write a status line without mixing prose into structured stdout.
+    /// The format must be resolved through `Context::format` to honor configuration.
+    pub fn write_status(
+        &mut self,
+        format: &crate::types::FormatOutput,
+        message: std::fmt::Arguments<'_>,
+    ) -> Result<()> {
+        let out = if format.is_machine_friendly_output() {
+            &mut self.err_out
+        } else {
+            &mut self.out
+        };
+        writeln!(out, "{message}")?;
+        Ok(())
+    }
+
     #[allow(dead_code)]
     pub fn write_output_for_vec<T: serde::Serialize + tabled::Tabled>(
         &mut self,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,20 +13,31 @@ macro_rules! svec {
     };
 }
 
+/// Tests that we don't write natural language status messages
+/// if the CLI is supposed to output json/yaml.
 #[test]
 fn status_output_respects_format() -> Result<()> {
     use crate::types::FormatOutput::{Json, Table, Yaml};
 
-    for (configured, explicit, expect_stderr) in [
-        (None, None, false),
-        (None, Some(Table), false),
-        (None, Some(Json), true),
-        (None, Some(Yaml), true),
-        (Some("json"), None, true),
-        (Some("yaml"), None, true),
-        (Some("json"), Some(Table), false),
-        (Some("table"), Some(Json), true),
-    ] {
+    enum WrittenTo {
+        Stdout,
+        Stderr,
+    }
+
+    #[rustfmt::skip]
+    let tests = [
+        // configured,  explicit,    expected
+        (None,          None,        WrittenTo::Stdout ),
+        (None,          Some(Table), WrittenTo::Stdout ),
+        (None,          Some(Json),  WrittenTo::Stderr ),
+        (None,          Some(Yaml),  WrittenTo::Stderr ),
+        (Some("json"),  None,        WrittenTo::Stderr ),
+        (Some("yaml"),  None,        WrittenTo::Stderr ),
+        (Some("json"),  Some(Table), WrittenTo::Stdout ),
+        (Some("table"), Some(Json),  WrittenTo::Stderr ),
+    ];
+    for (configured, explicit, expected) in tests {
+        // Set up context for this test.
         let mut config = TestConfig::new()?;
         if let Some(format) = configured {
             config.set("", "format", Some(format))?;
@@ -38,19 +49,32 @@ fn status_output_respects_format() -> Result<()> {
             debug: false,
             override_host: None,
         };
+
+        // Action: Write a status message wherever the context is configured.
         let format = ctx.format(&explicit)?;
         ctx.io.write_status(&format, format_args!("processed {} files", 4))?;
         drop(ctx);
 
-        let stdout = std::fs::read_to_string(&stdout_path)?;
-        let stderr = std::fs::read_to_string(&stderr_path)?;
+        // Validate that the status message was written where we expect.
+        let actual_stdout = std::fs::read_to_string(&stdout_path)?;
+        let actual_stderr = std::fs::read_to_string(&stderr_path)?;
         std::fs::remove_file(stdout_path)?;
         std::fs::remove_file(stderr_path)?;
         let status = "processed 4 files\n";
-        let expected = if expect_stderr { ("", status) } else { (status, "") };
+        let expected_stderr = match expected {
+            WrittenTo::Stdout => "",
+            WrittenTo::Stderr => status,
+        };
+        let expected_stdout = match expected {
+            WrittenTo::Stdout => status,
+            WrittenTo::Stderr => "",
+        };
         assert_eq!(
-            (stdout.as_str(), stderr.as_str()),
-            expected,
+            expected_stdout, actual_stdout,
+            "configured={configured:?}, explicit={explicit:?}"
+        );
+        assert_eq!(
+            expected_stderr, actual_stderr,
             "configured={configured:?}, explicit={explicit:?}"
         );
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,6 +13,8 @@ macro_rules! svec {
     };
 }
 
+mod structured_output;
+
 macro_rules! cli_tests {
     ($($name:ident($ctx:ident) => $body:block)+) => {
         $(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,49 @@ macro_rules! svec {
     };
 }
 
-mod structured_output;
+#[test]
+fn status_output_respects_format() -> Result<()> {
+    use crate::types::FormatOutput::{Json, Table, Yaml};
+
+    for (configured, explicit, expect_stderr) in [
+        (None, None, false),
+        (None, Some(Table), false),
+        (None, Some(Json), true),
+        (None, Some(Yaml), true),
+        (Some("json"), None, true),
+        (Some("yaml"), None, true),
+        (Some("json"), Some(Table), false),
+        (Some("table"), Some(Json), true),
+    ] {
+        let mut config = TestConfig::new()?;
+        if let Some(format) = configured {
+            config.set("", "format", Some(format))?;
+        }
+        let (io, stdout_path, stderr_path) = crate::iostreams::IoStreams::test();
+        let mut ctx = crate::context::Context {
+            config: &mut config,
+            io,
+            debug: false,
+            override_host: None,
+        };
+        let format = ctx.format(&explicit)?;
+        ctx.io.write_status(&format, format_args!("processed {} files", 4))?;
+        drop(ctx);
+
+        let stdout = std::fs::read_to_string(&stdout_path)?;
+        let stderr = std::fs::read_to_string(&stderr_path)?;
+        std::fs::remove_file(stdout_path)?;
+        std::fs::remove_file(stderr_path)?;
+        let status = "processed 4 files\n";
+        let expected = if expect_stderr { ("", status) } else { (status, "") };
+        assert_eq!(
+            (stdout.as_str(), stderr.as_str()),
+            expected,
+            "configured={configured:?}, explicit={explicit:?}"
+        );
+    }
+    Ok(())
+}
 
 macro_rules! cli_tests {
     ($($name:ident($ctx:ident) => $body:block)+) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ pub enum FormatOutput {
     Yaml,
     #[default]
     Table,
+    // If you add another variant, add it to the `variants()` method below too.
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, FromStr, Display, clap::ValueEnum, Copy)]
@@ -26,6 +27,16 @@ pub enum CameraView {
 impl FormatOutput {
     pub const fn variants() -> &'static [&'static str] {
         &["table", "json", "yaml"]
+    }
+
+    /// Whether stdout must be reserved for machine-readable output.
+    /// Human-readable status messages belong on stderr for these formats.
+    pub const fn is_machine_friendly_output(&self) -> bool {
+        match self {
+            FormatOutput::Json => true,
+            FormatOutput::Yaml => true,
+            FormatOutput::Table => false,
+        }
     }
 }
 


### PR DESCRIPTION
The Zoo CLI lets you specify an output format, including human-friendly output formats (like plaintext or tables) and machine-readable ones (JSON, YAML).

Human-friendly formats should log status messages (like "processed 4 files" or "wrote image to foo.png") to stdout, because that's where humans expect them. But for machine-readable formats (like json), they should log statuses to stderr, to avoid breaking parsers if you do `zoo | jq`.

Closes https://github.com/KittyCAD/cli/issues/1757